### PR TITLE
Generalize disc.count(NODES) for p2 elems

### DIFF
--- a/v2/src/lgr_disc.cpp
+++ b/v2/src/lgr_disc.cpp
@@ -217,7 +217,7 @@ int Disc::dim() { return mesh.dim(); }
 
 int Disc::count(EntityType type) {
   if (type == ELEMS) return mesh.nelems();
-  if (type == NODES) return mesh.nverts(); // linear specific!
+  if (type == NODES) return nodes2elems_.a2ab.size() - 1;
   OMEGA_H_NORETURN(-1);
 }
 


### PR DESCRIPTION
Still need to think about what to do for:
* node_coords()
* ents_on_closure(NODES)

I'll bring this up at the next meeting