### PR TITLE
Generalize vtk output

### DIFF
--- a/v2/src/lgr_element_functions.hpp
+++ b/v2/src/lgr_element_functions.hpp
@@ -119,6 +119,24 @@ Tri6Side::basis_values() {
   return out;
 }
 
+OMEGA_H_INLINE Vector<Tri6Side::points>
+Tri6Side::weights(Matrix<dim, nodes> node_coords) {
+  Vector<points> out;
+  auto x0 = node_coords[0][0];
+  auto x1 = node_coords[1][0];
+  auto x2 = node_coords[2][0];
+  out[0] =  1.0 / std::sqrt(3.0) * (x0 + x1 - 2.0 * x2) + 0.5 * (x1 - x0);
+  out[1] = -1.0 / std::sqrt(3.0) * (x0 + x1 - 2.0 * x2) + 0.5 * (x1 - x0);
+  return out;
+}
+
+OMEGA_H_INLINE constexpr double Tri6Side::lumping(int const node) {
+  return (
+      (node == 0) ? 1.0 / 6.0 :
+      (node == 1) ? 1.0 / 6.0 :
+      (node == 2) ? 1.0 / 3.0 : -1.0);
+}
+
 OMEGA_H_INLINE Matrix<Tri6::dim, Tri6::points> Tri6::pts() {
   Matrix<dim, points> out;
   out[0][0] = 2.0 / 3.0;

--- a/v2/src/lgr_vtk_output.cpp
+++ b/v2/src/lgr_vtk_output.cpp
@@ -6,6 +6,8 @@
 #include <lgr_simulation.hpp>
 #include <lgr_vtk_output.hpp>
 
+#include <Omega_h_print.hpp>
+
 namespace lgr {
 
 struct VtkOutput : public Response {
@@ -101,6 +103,12 @@ VtkOutput::VtkOutput(Simulation& sim_in, Omega_h::InputMap& pl) :
 
 void VtkOutput::respond() {
   Omega_h::ScopedTimer timer("VtkOutput::respond");
+  auto step = sim.step;
+  auto time = sim.time;
+  auto step_path = path + "/steps/step_" + std::to_string(step);
+  if (this->sim.comm->rank() == 0) {
+    Omega_h::vtk::update_pvd(path, &pvd_pos, step, time);
+  }
 }
 
 void VtkOutput::out_of_line_virtual_method() {

--- a/v2/src/lgr_vtk_output.cpp
+++ b/v2/src/lgr_vtk_output.cpp
@@ -1,5 +1,6 @@
 #include <Omega_h_file.hpp>
 #include <Omega_h_profile.hpp>
+#include <Omega_h_vtk.hpp>
 #include <lgr_field_index.hpp>
 #include <lgr_response.hpp>
 #include <lgr_simulation.hpp>
@@ -8,74 +9,90 @@
 namespace lgr {
 
 struct VtkOutput : public Response {
-  std::vector<FieldIndex> field_indices;
-  Omega_h::vtk::Writer writer;
-  Omega_h::TagSet tags;
-  VtkOutput(Simulation& sim_in, Omega_h::InputMap& pl)
-      : Response(sim_in, pl),
-        writer(pl.get<std::string>("path", "lgr_viz"), &sim.disc.mesh,
-            sim.dim(), sim.time, Omega_h::vtk::dont_compress) {
-    auto stdim = std::size_t(sim.dim());
-    std::map<std::string, std::size_t> omega_h_adapt_tags = {
-        {"quality", stdim}, {"metric", 0}};
-    std::map<std::string, std::pair<std::size_t, std::string>>
-        omega_h_multi_dim_tags = {{"element class_id", {stdim, "class_id"}},
-            {"node class_dim", {0, "class_dim"}}, {"node local", {0, "local"}},
-            {"node global", {0, "global"}}, {"element local", {stdim, "local"}},
-            {"element global", {stdim, "global"}}};
-    auto& field_names_in = pl.get_list("fields");
-    for (int i = 0; i < field_names_in.size(); ++i) {
-      auto field_name = field_names_in.get<std::string>(i);
-      if (omega_h_adapt_tags.count(field_name)) {
-        if (!sim.disc.mesh.has_tag(0, "metric"))
-          Omega_h::add_implied_isos_tag(&sim.disc.mesh);
-        tags[omega_h_adapt_tags[field_name]].insert(field_name);
-        continue;
-      }
-      if (omega_h_multi_dim_tags.count(field_name)) {
-        tags[omega_h_multi_dim_tags[field_name].first].insert(
-            omega_h_multi_dim_tags[field_name].second);
-        continue;
-      }
-      auto fi = sim.fields.find(field_name);
-      if (!fi.is_valid()) {
-        Omega_h_fail(
-            "Cannot visualize "
-            "undefined field \"%s\"\n",
-            field_name.c_str());
-      }
-      auto support = sim.fields[fi].support;
-      if (support->subset->entity_type == NODES) {
-        tags[0].insert(field_name);
-      } else if (support->subset->entity_type == ELEMS) {
-        if (support->on_points() && (sim.disc.points_per_ent(ELEMS) > 1)) {
-          Omega_h_fail(
-              "\"%s\" is on integration points, and there is more than one per "
-              "element, "
-              "and Dan hasn't coded support for visualizing that yet!\n",
-              field_name.c_str());
-        } else {
-          tags[std::size_t(sim.dim())].insert(field_name);
-        }
-      } else {
-        Omega_h_fail(
-            "\"%s\" is not on nodes or elements, VTK can't visualize it!\n",
-            field_name.c_str());
-      }
-      field_indices.push_back(fi);
-    }
-  }
-  void out_of_line_virtual_method() override;
-  void respond() override final {
-    Omega_h::ScopedTimer timer("VtkOutput::respond");
-    sim.disc.mesh.set_coords(sim.get(sim.position));  // linear specific!
-    sim.fields.copy_to_omega_h(sim.disc, field_indices);
-    writer.write(sim.step, sim.time, tags);
-    sim.fields.remove_from_omega_h(sim.disc, field_indices);
-  }
+  public:
+    VtkOutput(Simulation& sim_in, Omega_h::InputMap& pl);
+    void set_fields(Omega_h::InputMap& pl);
+    void out_of_line_virtual_method() override final;
+    void respond() override final;
+  public:
+    std::string path;
+    std::streampos pvd_pos;
+    std::vector<FieldIndex> lgr_fields;
+    std::vector<std::pair<int, std::string>> osh_fields;
 };
 
-void VtkOutput::out_of_line_virtual_method() {}
+void VtkOutput::set_fields(Omega_h::InputMap& pl) {
+  auto dim = sim.dim();
+  std::map<std::string, int> omega_h_adapt_tags = {
+        {"quality", dim}, {"metric", 0}};
+  std::map<std::string, std::pair<int, std::string>>
+    omega_h_multi_dim_tags = {{"element class_id", {dim, "class_id"}},
+      {"node class_dim", {0, "class_dim"}}, {"node local", {0, "local"}},
+      {"node global", {0, "global"}}, {"element local", {dim, "local"}},
+      {"element global", {dim, "global"}}};
+  auto& field_names_in = pl.get_list("fields");
+  for (int i = 0; i < field_names_in.size(); ++i) {
+    auto field_name = field_names_in.get<std::string>(i);
+    if (omega_h_adapt_tags.count(field_name)) {
+      if (!sim.disc.mesh.has_tag(0, "metric"))
+        Omega_h::add_implied_isos_tag(&sim.disc.mesh);
+      osh_fields.push_back({omega_h_adapt_tags[field_name], field_name});
+      continue;
+    }
+    if (omega_h_multi_dim_tags.count(field_name)) {
+      osh_fields.push_back({omega_h_multi_dim_tags[field_name].first,
+          omega_h_multi_dim_tags[field_name].second});
+        continue;
+    }
+    auto fi = sim.fields.find(field_name);
+    if (!fi.is_valid()) {
+      Omega_h_fail(
+          "Cannot visualize "
+          "undefined field \"%s\"\n",
+          field_name.c_str());
+    }
+    auto support = sim.fields[fi].support;
+    auto ent_type = support->subset->entity_type;
+    if (!(ent_type == NODES || ent_type == ELEMS)) {
+      Omega_h_fail(
+          "\"%s\" is not on nodes or elements, VTK can't visualize it!\n",
+          field_name.c_str());
+    }
+    if (ent_type == ELEMS) {
+      if (support->on_points() && (sim.disc.points_per_ent(ELEMS) > 1)) {
+        Omega_h_fail(
+            "\"%s\" is on integration points, and there is more than one per "
+            "element, "
+            "and Dan hasn't coded support for visualizing that yet!\n",
+            field_name.c_str());
+      }
+    }
+    lgr_fields.push_back(fi);
+  }
+}
+
+VtkOutput::VtkOutput(Simulation& sim_in, Omega_h::InputMap& pl) :
+  Response(sim_in, pl),
+  path(pl.get<std::string>("path", "lgr_viz")),
+  pvd_pos(0)
+{
+  auto comm = sim.comm;
+  auto rank = comm->rank();
+  if (rank == 0) Omega_h::safe_mkdir(path.c_str());
+  comm->barrier();
+  auto steps_dir = path + "/steps";
+  if (rank == 0) Omega_h::safe_mkdir(steps_dir.c_str());
+  comm->barrier();
+  if (rank == 0) pvd_pos = Omega_h::vtk::write_initial_pvd(path, sim.time);
+  set_fields(pl);
+}
+
+void VtkOutput::respond() {
+  Omega_h::ScopedTimer timer("VtkOutput::respond");
+}
+
+void VtkOutput::out_of_line_virtual_method() {
+}
 
 Response* vtk_output_factory(
     Simulation& sim, std::string const&, Omega_h::InputMap& pl) {

--- a/v2/src/lgr_vtk_output.cpp
+++ b/v2/src/lgr_vtk_output.cpp
@@ -8,8 +8,6 @@
 #include <lgr_simulation.hpp>
 #include <lgr_vtk_output.hpp>
 
-#include <Omega_h_print.hpp>
-
 namespace lgr {
 
 using LgrFields = std::set<std::size_t>;

--- a/v2/src/lgr_vtk_output.cpp
+++ b/v2/src/lgr_vtk_output.cpp
@@ -186,7 +186,7 @@ enum {
 static Omega_h::I8 vtk_type(Disc& disc) {
   auto dim = disc.dim();
   auto family = disc.mesh.family();
-  int orderm1 = (disc.is_simplex_ == 0) ? 0 : 1;
+  int orderm1 = (disc.is_second_order_ == true) ? 1 : 0;
   if (family == OMEGA_H_SIMPLEX) {
     Omega_h::I8 simplex_table[4][2] = {
       {VTK_VERTEX, VTK_VERTEX},


### PR DESCRIPTION
This should allow:

* Linear meshes to be output to vtk exactly as they were
* Quadratic meshes to be output to vtk with nodal data that exists at all nodes
* Output to vtk for element data that exists at more than a single integration point
* Had to throw in some extra functions for Tri6 to get that to compile again

This depends on the PR:
https://github.com/ibaned/omega_h/pull/276