### PR TITLE
Restructure GTest unit testing: consolidate unit tests into a single

### DIFF
--- a/v3/CMakeLists.txt
+++ b/v3/CMakeLists.txt
@@ -20,7 +20,6 @@ else()
 endif()
 
 set(LGR_SOURCES
-    lgr.cpp
     lgr_state.cpp
     lgr_vtk.cpp
     lgr_domain.cpp
@@ -51,32 +50,26 @@ if (LGR_ENABLE_CUDA)
   set_source_files_properties(${LGR_SOURCES} PROPERTIES LANGUAGE CUDA)
 endif()
 
-add_executable(lgr ${LGR_SOURCES})
+add_library(lgrlib ${LGR_SOURCES})
+set_property(TARGET lgrlib PROPERTY CXX_STANDARD "14")
+set_property(TARGET lgrlib PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET lgrlib PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET lgrlib PROPERTY OUTPUT_NAME lgr)
+target_include_directories(lgrlib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
+if (LGR_ENABLE_EXODUS)
+  target_compile_definitions(lgrlib PUBLIC -DLGR_ENABLE_EXODUS)
+  target_link_libraries(lgrlib PUBLIC exodus)
+  target_include_directories(lgrlib PUBLIC "${SEACASExodus_INCLUDE_DIRS}")
+  target_include_directories(lgrlib PUBLIC "${SEACASExodus_TPL_INCLUDE_DIRS}")
+  target_link_libraries(lgrlib PUBLIC "${SEACASExodus_TPL_LIBRARIES}")
+  target_include_directories(lgrlib PUBLIC "${MPI_CXX_INCLUDE_DIRS}")
+endif()
+
+add_executable(lgr lgr.cpp)
 set_property(TARGET lgr PROPERTY CXX_STANDARD "14")
 set_property(TARGET lgr PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET lgr PROPERTY CXX_EXTENSIONS OFF)
-target_include_directories(lgr
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-if (LGR_ENABLE_EXODUS)
-  target_compile_definitions(lgr PRIVATE -DLGR_ENABLE_EXODUS)
-  target_link_libraries(lgr PRIVATE exodus)
-  target_include_directories(lgr PRIVATE "${SEACASExodus_INCLUDE_DIRS}")
-  target_include_directories(lgr PRIVATE "${SEACASExodus_TPL_INCLUDE_DIRS}")
-# target_link_libraries(lgr PRIVATE "${SEACASExodus_TPL_LIBRARIES}")
-  target_include_directories(lgr PRIVATE "${MPI_CXX_INCLUDE_DIRS}")
-endif()
+target_link_libraries(lgr lgrlib)
 
-option(LGR_ENABLE_UNIT_TESTS "Build support for unit tests" ON)
-if (LGR_ENABLE_UNIT_TESTS AND NOT LGR_ENABLE_CUDA)
-  find_package(GTest REQUIRED)
-  include(GoogleTest)
-  add_executable(ut_tensor unit_tests/tensor.cpp)
-  add_executable(ut_maxent unit_tests/maxent.cpp otm_meshless.cpp)
-  gtest_add_tests(TARGET ut_tensor)
-  gtest_add_tests(TARGET ut_maxent)
-  target_include_directories(ut_tensor PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> ${GTEST_INCLUDE_DIR})
-  target_include_directories(ut_maxent PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> ${GTEST_INCLUDE_DIR})
-  target_link_libraries(ut_tensor PRIVATE ${GTEST_LIBRARY} pthread)
-  target_link_libraries(ut_maxent PRIVATE ${GTEST_LIBRARY} pthread)
-endif()
+add_subdirectory(unit_tests)

--- a/v3/unit_tests/CMakeLists.txt
+++ b/v3/unit_tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+option(LGR_ENABLE_UNIT_TESTS "Build support for unit tests" ON)
+
+if (LGR_ENABLE_UNIT_TESTS AND NOT LGR_ENABLE_CUDA)
+
+  set(LGR_UNIT_SOURCES
+    tensor.cpp
+    maxent.cpp
+    exodus.cpp
+    ut_main.cpp)
+
+  include(CTest)
+
+  find_package(GTest REQUIRED)
+  include(GoogleTest)
+  add_executable(ut_lgr ${LGR_UNIT_SOURCES})
+  set_property(TARGET ut_lgr PROPERTY CXX_STANDARD "14")
+  set_property(TARGET ut_lgr PROPERTY CXX_STANDARD_REQUIRED ON)
+  set_property(TARGET ut_lgr PROPERTY CXX_EXTENSIONS OFF)
+  gtest_discover_tests(ut_lgr)
+  target_include_directories(ut_lgr PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> ${GTEST_INCLUDE_DIR})
+  target_link_libraries(ut_lgr PRIVATE "lgrlib;${GTEST_LIBRARY};pthread")
+endif()

--- a/v3/unit_tests/exodus.cpp
+++ b/v3/unit_tests/exodus.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <lgr_exodus.hpp>
+#include <lgr_input.hpp>
+#include <lgr_mesh_indices.hpp>
+#include <lgr_state.hpp>
+
+using namespace lgr;
+
+TEST(exodus, DISABLED_readSimpleFile) {
+    using nodes_size_type = hpc::counting_range<node_index>::size_type;
+    using elems_size_type = hpc::counting_range<element_index>::size_type;
+
+    material_index mat(1);
+    material_index bnd(1);
+    input in(mat, bnd);
+    state st;
+
+    int err_code = read_exodus_file("test.g", in, st);
+
+    ASSERT_EQ(err_code, 0);
+
+    EXPECT_EQ(st.nodes.size(), nodes_size_type(0));
+    EXPECT_EQ(st.elements.size(), elems_size_type(0));
+}

--- a/v3/unit_tests/maxent.cpp
+++ b/v3/unit_tests/maxent.cpp
@@ -6,15 +6,6 @@
 #include <otm_meshless.hpp>
 #include <iostream>
 
-int
-main(int ac, char* av[])
-{
-  ::testing::GTEST_FLAG(print_time) = true;
-  ::testing::InitGoogleTest(&ac, av);
-  auto const retval = RUN_ALL_TESTS();
-  return retval;
-}
-
 void
 tetrahedron_single_point(lgr::state& s)
 {

--- a/v3/unit_tests/tensor.cpp
+++ b/v3/unit_tests/tensor.cpp
@@ -21,15 +21,6 @@ operator<<(std::ostream & os, hpc::matrix3x3<T> const & A)
   return os;
 }
 
-int
-main(int ac, char* av[])
-{
-  ::testing::GTEST_FLAG(print_time) = true;
-  ::testing::InitGoogleTest(&ac, av);
-  auto const retval = RUN_ALL_TESTS();
-  return retval;
-}
-
 TEST(tensor, exp)
 {
   auto const eps = hpc::machine_epsilon<Real>();

--- a/v3/unit_tests/ut_main.cpp
+++ b/v3/unit_tests/ut_main.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+int
+main(int argc, char* argv[])
+{
+  ::testing::GTEST_FLAG(print_time) = true;
+  ::testing::InitGoogleTest(&argc, argv);
+  auto const retval = RUN_ALL_TESTS();
+  return retval;
+}


### PR DESCRIPTION
  executable, eliminate duplicate mains, and enable CTest.

  Add a stub for exodus interface unit tests.