### PR TITLE
Implement and add test of ArborX search

### DIFF
--- a/v3/otm_arborx_search_impl.cpp
+++ b/v3/otm_arborx_search_impl.cpp
@@ -1,55 +1,83 @@
-#include <ArborX_Point.hpp>
+#include <ArborX_LinearBVH.hpp>
+#include <ArborX_Predicates.hpp>
+#include <hpc_array.hpp>
 #include <hpc_array_vector.hpp>
+#include <hpc_dimensional.hpp>
+#include <hpc_macros.hpp>
 #include <hpc_range.hpp>
-#include <hpc_vector3.hpp>
 #include <Kokkos_Core.hpp>
-#include <lgr_mesh_indices.hpp>
+#include <Kokkos_Pair.hpp>
 #include <lgr_state.hpp>
 #include <otm_arborx_search_impl.hpp>
+#include <string>
+
+using Kokkos::tie;
 
 namespace lgr {
 namespace search {
-namespace impl {
+namespace arborx {
 
-using device_range_type = Kokkos::RangePolicy<device_exec_space>;
+using device_range = Kokkos::RangePolicy<device_exec_space>;
+using device_bvh = ArborX::BoundingVolumeHierarchy<lgr::search::arborx::device_exec_space>;
+
 using Kokkos::parallel_for;
+using Kokkos::fence;
 
-device_point_view create_arborx_nodes(const lgr::state& s)
+HPC_NOINLINE device_search_results do_search(device_point_view nodes,
+    device_nearest_query_view queries)
 {
-  device_point_view search_nodes("nodes", s.nodes.size());
+  device_bvh bvh(nodes);
+  device_int_view offsets("offsets", 0);
+  device_int_view indices("indices", 0);
+  bvh.query(queries, indices, offsets);
+  return tie(offsets, indices);
+}
 
-  auto nodes_to_x = s.x.cbegin();
-  device_range_type node_range(0, search_nodes.extent(0));
-  parallel_for(node_range, KOKKOS_LAMBDA(int node_idx)
+HPC_NOINLINE device_nearest_query_view make_nearest_node_queries(device_point_view points,
+    const int num_nodes_to_find)
+{
+  const int numQueries = points.extent(0);
+  device_nearest_query_view queries(
+      Kokkos::ViewAllocateWithoutInitializing("queries"), numQueries);
+
+  parallel_for("setup_queries", device_range(0, numQueries),
+  KOKKOS_LAMBDA(int i)
   {
-    using NI = lgr::node_index;
-    auto&& search_node = search_nodes(node_idx);
-    auto&& lgr_node_coord = nodes_to_x[NI(node_idx)].load();
+    queries(i) = ArborX::nearest(points(i), num_nodes_to_find);
+  });
+  fence();
+  return queries;
+}
+
+template<typename idx_type>
+HPC_NOINLINE device_point_view make_point_view(
+    const std::string& view_name,
+    const hpc::counting_range<idx_type>& lgr_points,
+    const hpc::device_array_vector<hpc::position<double>, idx_type>& coords)
+{
+  device_point_view search_points(view_name, lgr_points.size());
+  auto points_to_x = coords.cbegin();
+  device_range point_range(0, search_points.extent(0));
+  parallel_for(point_range, KOKKOS_LAMBDA(int node_idx)
+  {
+    auto&& search_node = search_points(node_idx);
+    auto&& lgr_node_coord = points_to_x[idx_type(node_idx)].load();
     search_node[0] = lgr_node_coord(0);
     search_node[1] = lgr_node_coord(1);
     search_node[2] = lgr_node_coord(2);
   });
-
-  return search_nodes;
+  fence();
+  return search_points;
 }
 
-device_point_view create_arborx_points(const lgr::state& s)
+HPC_NOINLINE device_point_view create_arborx_nodes(const lgr::state& s)
 {
-  device_point_view search_points("points", s.points.size());
+  return make_point_view("nodes", s.nodes, s.x);
+}
 
-  auto mat_pts_to_x = s.xm.cbegin();
-  device_range_type pt_range(0, search_points.extent(0));
-  parallel_for(pt_range, KOKKOS_LAMBDA(int pt_idx)
-  {
-    using PI = lgr::point_index;
-    auto&& search_pt = search_points(pt_idx);
-    auto&& lgr_pt_coord = mat_pts_to_x[PI(pt_idx)].load();
-    search_pt[0] = lgr_pt_coord(0);
-    search_pt[1] = lgr_pt_coord(1);
-    search_pt[2] = lgr_pt_coord(2);
-  });
-
-  return search_points;
+HPC_NOINLINE device_point_view create_arborx_points(const lgr::state& s)
+{
+  return make_point_view("points", s.points, s.xm);
 }
 
 }

--- a/v3/otm_arborx_search_impl.hpp
+++ b/v3/otm_arborx_search_impl.hpp
@@ -7,19 +7,30 @@ class state;
 }
 
 namespace ArborX {
+class Box;
 class Point;
+template <typename GeomType> class Nearest;
 }
 
 namespace lgr {
 namespace search {
-namespace impl {
+namespace arborx {
 
 using device_exec_space = Kokkos::DefaultExecutionSpace;
 using device_point_view = Kokkos::View<ArborX::Point *, device_exec_space>;
+using device_nearest_query_view = Kokkos::View<ArborX::Nearest<ArborX::Point> *, device_exec_space>;
+using device_int_view = Kokkos::View<int *, device_exec_space>;
+using device_search_results = Kokkos::pair<device_int_view, device_int_view>;
 
-device_point_view create_arborx_nodes(const lgr::state& s);
+device_point_view create_arborx_nodes(const lgr::state &s);
 
-device_point_view create_arborx_points(const lgr::state& s);
+device_point_view create_arborx_points(const lgr::state &s);
+
+device_nearest_query_view make_nearest_node_queries(device_point_view points,
+    const int num_nodes_to_find);
+
+device_search_results do_search(device_point_view nodes,
+    device_nearest_query_view queries);
 
 }
 }

--- a/v3/unit_tests/search.cpp
+++ b/v3/unit_tests/search.cpp
@@ -1,3 +1,4 @@
+#include <ArborX_LinearBVH.hpp>
 #include <gtest/gtest.h>
 #include <hpc_algorithm.hpp>
 #include <hpc_execution.hpp>
@@ -10,6 +11,7 @@
 #include <otm_search.hpp>
 #include <unit_tests/otm_unit_mesh.hpp>
 #include <ArborX_Point.hpp>
+#include <ArborX_Predicates.hpp>
 
 class search : public ::testing::Test
 {
@@ -30,7 +32,7 @@ TEST_F(search, canInitializeArborXNodesFromOTMNodes)
 
   tetrahedron_single_point(s);
 
-  auto search_nodes = lgr::search::impl::create_arborx_nodes(s);
+  auto search_nodes = lgr::search::arborx::create_arborx_nodes(s);
 
   EXPECT_EQ(search_nodes.extent(0), 4);
 
@@ -52,7 +54,7 @@ TEST_F(search, canInitializeArborXPointsFromOTMPoints)
 
   tetrahedron_single_point(s);
 
-  auto search_points = lgr::search::impl::create_arborx_points(s);
+  auto search_points = lgr::search::arborx::create_arborx_points(s);
 
   EXPECT_EQ(search_points.extent(0), 1);
 
@@ -63,6 +65,42 @@ TEST_F(search, canInitializeArborXPointsFromOTMPoints)
     EXPECT_DOUBLE_EQ(lgr_pt_coord(0), search_pt_coord[0]);
     EXPECT_DOUBLE_EQ(lgr_pt_coord(1), search_pt_coord[1]);
     EXPECT_DOUBLE_EQ(lgr_pt_coord(2), search_pt_coord[2]);
+  };
+
+  hpc::for_each(hpc::device_policy(), s.points, pt_check_func);
+}
+
+TEST_F(search, canDoNearestNodePointSearch) {
+  lgr::state s;
+  tetrahedron_single_point(s);
+
+  auto search_nodes = lgr::search::arborx::create_arborx_nodes(s);
+  auto search_points = lgr::search::arborx::create_arborx_points(s);
+  const int num_nodes_per_point_to_find = 4;
+  auto queries = lgr::search::arborx::make_nearest_node_queries(search_points, num_nodes_per_point_to_find);
+
+  lgr::search::arborx::device_int_view offsets;
+  lgr::search::arborx::device_int_view indices;
+  Kokkos::tie(offsets, indices) = lgr::search::arborx::do_search(search_nodes, queries);
+
+  int num_points = search_points.extent(0);
+  auto nodes_to_x = s.x.cbegin();
+
+  EXPECT_EQ(num_points, 1);
+
+  auto pt_check_func = HPC_DEVICE [=](lgr::point_index point) {
+    auto point_begin = offsets(hpc::weaken(point));
+    auto point_end = offsets(hpc::weaken(point)+1);
+    EXPECT_EQ(point_end - point_begin, 4);
+    for (auto j=point_begin; j<point_end; ++j)
+    {
+      auto search_node_coord = search_nodes(indices(j));
+      auto&& lgr_node_coord = nodes_to_x[indices(j)].load();
+      EXPECT_DOUBLE_EQ(lgr_node_coord(0), search_node_coord[0]);
+      EXPECT_DOUBLE_EQ(lgr_node_coord(1), search_node_coord[1]);
+      EXPECT_DOUBLE_EQ(lgr_node_coord(2), search_node_coord[2]);
+
+    }
   };
 
   hpc::for_each(hpc::device_policy(), s.points, pt_check_func);


### PR DESCRIPTION
@lxmota The search is currently based on finding the nearest 4 nodes to a given material point in space. This can easily be adapted to search, e.g., for spheres surrounding nodes which intersect a given point, and vice-versa.