### PR TITLE
OTM: invert connectivities for assembly routines.

### DIFF
--- a/v3/lgr_mesh_indices.hpp
+++ b/v3/lgr_mesh_indices.hpp
@@ -21,8 +21,9 @@ struct point_in_element_tag {};
 using point_in_element_index = hpc::index<point_in_element_tag, int>;
 using point_index = decltype(element_index() * point_in_element_index());
 using element_node_index = decltype(element_index() * node_in_element_index());
-using point_node_index = decltype(point_index() * node_in_element_index());
-using node_point_index = decltype(node_index() * point_in_influence_index());
+using point_node_index = decltype(point_index() * node_in_support_index());
+struct node_point_tag {};
+using node_point_index = hpc::index<node_point_tag, int>;
 struct material_tag {};
 using material_index = hpc::index<material_tag, int>;
 

--- a/v3/lgr_meshing_sort.hpp
+++ b/v3/lgr_meshing_sort.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <hpc_algorithm.hpp>
+#include <hpc_execution.hpp>
+#include <hpc_macros.hpp>
+#include <lgr_mesh_indices.hpp>
+#include <lgr_state.hpp>
+#include <cassert>
+
+namespace lgr {
+
+template<typename NodeRelRangeType, typename NodeRelToRelRangeType,
+    typename NodeRelToNodesOfRelRangeType>
+void sort_node_relations(lgr::state &s, NodeRelRangeType &nodes_to_node_relations,
+    NodeRelToRelRangeType &node_relations_to_relation_indices,
+    NodeRelToNodesOfRelRangeType &node_relations_to_nodes_of_relation)
+{
+  auto node_rels = nodes_to_node_relations.cbegin();
+  auto node_rel_to_rel = node_relations_to_relation_indices.begin();
+  auto node_rel_to_nodes_of_node_rel = node_relations_to_nodes_of_relation.begin();
+  auto sort_functor =
+      [=] HPC_DEVICE (
+          node_index const node)
+          {
+            auto const this_node_rel = node_rels[node];
+            typename NodeRelRangeType::value_type const except_last(this_node_rel.begin(), this_node_rel.end() - 1);
+            for (auto const nr : except_last)
+            {
+              typename NodeRelRangeType::value_type const remaining(nr + 1, this_node_rel.end());
+              auto min_rel(node_rel_to_rel[nr]);
+              auto min_node_rel = nr;
+              for (auto const nr2 : remaining)
+              {
+                auto const relation = node_rel_to_rel[nr2];
+                if (relation < min_rel)
+                {
+                  min_rel = relation;
+                  min_node_rel = nr2;
+                }
+              }
+              hpc::swap(node_rel_to_rel[nr], node_rel_to_rel[min_node_rel]);
+              hpc::swap(node_rel_to_nodes_of_node_rel[nr], node_rel_to_nodes_of_node_rel[min_node_rel]);
+            }
+#ifndef NDEBUG
+          for (auto i(*(this_node_rel.begin())); i < (*(this_node_rel.end())) - 1; ++i)
+          {
+            assert(node_rel_to_rel[i] < node_rel_to_rel[i + 1]);
+          }
+#endif
+        };
+  hpc::for_each(hpc::device_policy(), s.nodes, sort_functor);
+}
+
+}

--- a/v3/lgr_state.hpp
+++ b/v3/lgr_state.hpp
@@ -21,14 +21,15 @@ class state {
   hpc::time<double> time = 0.0;
   hpc::counting_range<element_index> elements{element_index(0)};
   hpc::counting_range<node_in_element_index> nodes_in_element{node_in_element_index(0)};
-  hpc::device_range_sum<point_node_index, point_index> nodes_in_support; // OTM: Support nodes for each material point
-  hpc::device_range_sum<node_point_index, node_index> points_in_influence; // OTM: Influence points for each node
+  hpc::device_range_sum<point_node_index, point_index> nodes_in_support; // OTM: Support for each material point
+  hpc::device_range_sum<point_in_influence_index, node_index> points_in_influence;
   hpc::counting_range<node_index> nodes{node_index(0)};
   hpc::counting_range<point_in_element_index> points_in_element{point_in_element_index(1)};
   hpc::counting_range<point_index> points{point_index(0)};
   hpc::device_vector<node_index, element_node_index> elements_to_nodes;
   hpc::device_vector<node_index, point_node_index> points_to_supported_nodes;
   hpc::device_vector<point_index, node_index> nodes_to_influenced_points;
+  hpc::device_vector<node_in_support_index, node_point_index> node_influenced_points_to_supporting_nodes;
   hpc::device_range_sum<node_element_index, node_index> nodes_to_node_elements;
   hpc::device_vector<element_index, node_element_index> node_elements_to_elements;
   hpc::device_vector<node_in_element_index, node_element_index> node_elements_to_nodes_in_element;

--- a/v3/otm_search.cpp
+++ b/v3/otm_search.cpp
@@ -1,16 +1,19 @@
 #include <hpc_algorithm.hpp>
-#include <hpc_array_vector.hpp>
+#include <hpc_atomic.hpp>
 #include <hpc_execution.hpp>
 #include <hpc_index.hpp>
 #include <hpc_macros.hpp>
+#include <hpc_numeric.hpp>
 #include <hpc_range.hpp>
 #include <hpc_range_sum.hpp>
 #include <hpc_vector.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Pair.hpp>
 #include <lgr_mesh_indices.hpp>
+#include <lgr_meshing_sort.hpp>
 #include <lgr_state.hpp>
 #include <otm_arborx_search_impl.hpp>
+#include <cassert>
 
 namespace lgr {
 namespace search {
@@ -25,13 +28,56 @@ void finalize_otm_search()
   Kokkos::finalize();
 }
 
-HPC_NOINLINE void do_otm_point_node_search(lgr::state &s)
+void invert_otm_point_node_relations(lgr::state &s)
+{
+  auto points_to_point_nodes = s.nodes_in_support.cbegin();
+  auto point_nodes_to_nodes = s.points_to_supported_nodes.cbegin();
+  hpc::device_vector<int, node_index> node_point_counts(s.nodes.size(), 0);
+  auto counts = node_point_counts.begin();
+  auto point_count_functor = [=] HPC_DEVICE(point_index const point) {
+    auto point_node_range = points_to_point_nodes[point];
+    for(auto point_node : point_node_range) {
+      auto node = point_nodes_to_nodes[point_node];
+      hpc::atomic_ref<int> count(counts[node]);
+      count++;
+    }
+  };
+  hpc::for_each(hpc::device_policy(), s.points, point_count_functor);
+  auto total_node_points = hpc::reduce(hpc::device_policy(), node_point_counts, 0);
+
+  s.nodes_to_influenced_points.resize(node_point_index(total_node_points));
+  s.node_influenced_points_to_supporting_nodes.resize(node_point_index(total_node_points));
+  s.points_in_influence.assign_sizes(node_point_counts);
+  hpc::fill(hpc::device_policy(), node_point_counts, 0);
+  auto node_points_to_points = s.nodes_to_influenced_points.begin();
+  auto points_in_influence = s.points_in_influence.cbegin();
+  auto node_points_to_supporting_nodes = s.node_influenced_points_to_supporting_nodes.begin();
+  auto node_point_fill_functor = [=] HPC_DEVICE(point_index const point)
+  {
+    auto const point_nodes = points_to_point_nodes[point];
+    for (auto ni = 0; ni < point_nodes.size(); ++ni)
+    {
+      const auto point_node = point_nodes[ni];
+      node_index const node = point_nodes_to_nodes[point_node];
+      hpc::atomic_ref<int> count(counts[node]);
+      int const offset = count++;
+      auto const node_points_range = points_in_influence[node];
+      auto const node_point = node_points_range[node_in_support_index(offset)];
+      node_points_to_points[node_point] = point;
+      node_points_to_supporting_nodes[node_point] = ni;
+    }
+  };
+
+  hpc::for_each(hpc::device_policy(), s.points, node_point_fill_functor);
+
+  sort_node_relations(s, s.points_in_influence, s.nodes_to_influenced_points, s.node_influenced_points_to_supporting_nodes);
+}
+
+HPC_NOINLINE void do_otm_point_node_search(lgr::state &s, int max_support_nodes_per_point)
 {
   auto search_nodes = arborx::create_arborx_nodes(s);
   auto search_points = arborx::create_arborx_points(s);
-  const int num_nodes_per_point_to_find = 4;
-  auto queries = arborx::make_nearest_node_queries(search_points,
-      num_nodes_per_point_to_find);
+  auto queries = arborx::make_nearest_node_queries(search_points, max_support_nodes_per_point);
 
   arborx::device_int_view offsets;
   arborx::device_int_view indices;
@@ -39,30 +85,29 @@ HPC_NOINLINE void do_otm_point_node_search(lgr::state &s)
 
   hpc::device_vector<int, point_index> counts(s.points.size());
   auto points_node_count = counts.begin();
-  auto count_func =
-      HPC_DEVICE [=](
-          lgr::point_index point)
-          {
-            auto point_begin = offsets(hpc::weaken(point));
-            auto point_end = offsets(hpc::weaken(point) + 1);
-            points_node_count[hpc::weaken(point)] = point_index(point_end - point_begin);
-          };
+  auto count_func = HPC_DEVICE [=](lgr::point_index point)
+  {
+    auto point_begin = offsets(hpc::weaken(point));
+    auto point_end = offsets(hpc::weaken(point) + 1);
+    points_node_count[hpc::weaken(point)] = point_index(point_end - point_begin);
+  };
   hpc::for_each(hpc::device_policy(), s.points, count_func);
 
   s.nodes_in_support.assign_sizes(counts);
 
   auto points_to_nodes_of_point = s.nodes_in_support.cbegin();
   auto points_to_supported_nodes = s.points_to_supported_nodes.begin();
-  auto fill_func =
-      HPC_DEVICE [=](
-          lgr::point_index point)
-          {
-            auto const point_nodes_range = points_to_nodes_of_point[point];
-            for (auto point_node : point_nodes_range)
-            {
-              points_to_supported_nodes[point_node] = indices(hpc::weaken(point_node));
-            }
-          };
+  auto fill_func = HPC_DEVICE [=](lgr::point_index point)
+  {
+    auto const point_nodes_range = points_to_nodes_of_point[point];
+    for (auto point_node : point_nodes_range)
+    {
+      points_to_supported_nodes[point_node] = indices(hpc::weaken(point_node));
+    }
+  };
+  hpc::for_each(hpc::device_policy(), s.points, fill_func);
+
+  invert_otm_point_node_relations(s);
 }
 
 }

--- a/v3/otm_search.hpp
+++ b/v3/otm_search.hpp
@@ -7,7 +7,9 @@ void initialize_otm_search();
 
 void finalize_otm_search();
 
-void do_otm_point_node_search(lgr::state &s);
+void do_otm_point_node_search(lgr::state &s, int max_support_nodes_per_point);
+
+void invert_otm_point_node_relations(lgr::state & s);
 
 }
 }

--- a/v3/otm_tet2meshless.cpp
+++ b/v3/otm_tet2meshless.cpp
@@ -13,8 +13,6 @@ namespace lgr {
 
 void convert_tet_mesh_to_meshless(state& st)
 {
-  using nodes_in_elem_size_type = hpc::counting_range<node_in_element_index>::size_type;
-
   auto num_points = st.points.size();
   auto num_nodes_in_support = st.nodes_in_element.size();
   st.points_to_supported_nodes.resize(num_points * num_nodes_in_support);
@@ -26,8 +24,8 @@ void convert_tet_mesh_to_meshless(state& st)
   auto points_in_element = st.points_in_element;
   auto elements_to_points = st.elements * st.points_in_element;
 
-  hpc::device_vector<point_index> nodes_in_support_counts(st.points.size(),
-      point_index(st.nodes_in_element.size()));
+  hpc::device_vector<int, point_index> nodes_in_support_counts(st.points.size(),
+      st.nodes_in_element.size());
   st.nodes_in_support.assign_sizes(nodes_in_support_counts);
 
   auto support_nodes_to_nodes = st.points_to_supported_nodes.begin();
@@ -40,28 +38,20 @@ void convert_tet_mesh_to_meshless(state& st)
     auto cur_elem_points = elements_to_points[element];
     auto element_nodes = elements_to_element_nodes[element];
 
-    constexpr nodes_in_elem_size_type max_num_elem_nodes = 10;
-    hpc::array<node_index, max_num_elem_nodes> cur_elem_nodes;
-
-    hpc::position<double> avg_coord(0., 0., 0.);
-    for (auto n : nodes_in_element)
-    {
-      auto cur_elem_node_offset = element_nodes[n];
-      auto node = element_nodes_to_nodes[cur_elem_node_offset];
-      cur_elem_nodes[n] = node;
-      avg_coord += nodes_to_x[node].load();
-    }
-    avg_coord /= nodes_in_element.size();
-
     for (auto&& element_point : points_in_element)
     {
+      hpc::position<double> avg_coord(0., 0., 0.);
       auto point = cur_elem_points[element_point];
-      mat_pts_to_x[point].store(avg_coord);
       auto&& point_support_nodes = nodes_in_support[point];
       for (auto&& n : nodes_in_element)
       {
-        support_nodes_to_nodes[point_support_nodes[n]] = cur_elem_nodes[n];
+        auto cur_elem_node_offset = element_nodes[n];
+        auto node = element_nodes_to_nodes[cur_elem_node_offset];
+        avg_coord += nodes_to_x[node].load();
+        support_nodes_to_nodes[point_support_nodes[n]] = node;
       }
+      avg_coord /= nodes_in_element.size();
+      mat_pts_to_x[point] = avg_coord;
     }
   };
 


### PR DESCRIPTION
  Fix search call to fill data structures, update results checking function in
  unit test.

  Disable connectivity checking for Exodus mesh while we develop a better
  search algorithm.