### PR TITLE
OTM: Add ability to specify Gauss point locations and interpolate to …

### DIFF
--- a/v3/lgr_input.hpp
+++ b/v3/lgr_input.hpp
@@ -10,6 +10,7 @@
 #include <lgr_hyper_ep/model.hpp>
 #endif
 #include <hpc_vector.hpp>
+#include <hpc_range_sum.hpp>
 #include <hpc_dimensional.hpp>
 
 namespace lgr {
@@ -56,6 +57,7 @@ class input {
   hpc::length<double> y_domain_size = 1.0;
   int elements_along_z = 0;
   hpc::length<double> z_domain_size = 1.0;
+  int otm_material_points_to_add_per_element = 1;
   bool output_to_command_line = true;
   hpc::host_vector<hpc::density<double>, material_index> rho0;
   hpc::host_vector<hpc::specific_energy<double>, material_index> e0;
@@ -124,6 +126,12 @@ class input {
         hpc::device_array_vector<hpc::velocity<double>, node_index>*)> initial_v;
   std::vector<zero_acceleration_condition> zero_acceleration_conditions;
   std::function<void(hpc::device_array_vector<hpc::position<double>, node_index>*)> x_transform;
+  std::function<
+    void(hpc::counting_range<point_index> const,
+        hpc::device_range_sum<point_node_index, point_index> const&,
+        hpc::device_vector<node_index, point_node_index> const&,
+        hpc::device_array_vector<hpc::position<double>, node_index> const&,
+        hpc::device_array_vector<hpc::position<double>, point_index>&)> xp_transform;
   hpc::host_vector<std::unique_ptr<domain>, material_index> domains;
   input() = delete;
   input(material_index const material_count_in, material_index const boundary_count_in)

--- a/v3/otm_tet2meshless.cpp
+++ b/v3/otm_tet2meshless.cpp
@@ -9,15 +9,17 @@
 #include <hpc_symmetric3x3.hpp>
 #include <hpc_vector.hpp>
 #include <hpc_vector3.hpp>
+#include <lgr_input.hpp>
 #include <lgr_mesh_indices.hpp>
 #include <lgr_state.hpp>
 #include <otm_meshing.hpp>
 
 namespace lgr {
 
-void convert_tet_mesh_to_meshless(state& st)
+void convert_tet_mesh_to_meshless(state& st, const input& in)
 {
-  auto const num_points = st.points.size();
+  auto const num_points = st.elements.size() * in.otm_material_points_to_add_per_element;
+  st.points.resize(num_points);
   auto const num_nodes_in_support = st.nodes_in_element.size();
   st.point_nodes_to_nodes.resize(num_points * num_nodes_in_support);
   st.xp.resize(num_points);
@@ -26,55 +28,56 @@ void convert_tet_mesh_to_meshless(state& st)
   auto const nodes_in_element = st.nodes_in_element;
   auto const elements_to_element_nodes = st.elements * st.nodes_in_element;
   auto const element_nodes_to_nodes = st.elements_to_nodes.cbegin();
-  auto const points_in_element = st.points_in_element;
-  auto const elements_to_points = st.elements * st.points_in_element;
+  auto const points_in_support = hpc::make_counting_range(in.otm_material_points_to_add_per_element);
+  auto const elements_to_points = st.elements * points_in_support;
 
   hpc::device_vector<int, point_index> nodes_in_support_counts(st.points.size(),
       st.nodes_in_element.size());
   st.points_to_point_nodes.assign_sizes(nodes_in_support_counts);
 
   auto const support_nodes_to_nodes = st.point_nodes_to_nodes.begin();
-
-  auto const nodes_to_x = st.x.cbegin();
-  auto const mat_pts_to_x = st.xp.begin();
-  auto const mat_pts_to_h = st.h_otm.begin();
   auto const nodes_in_support = st.points_to_point_nodes.cbegin();
   auto func = [=] HPC_DEVICE (element_index const element)
   {
     auto const cur_elem_points = elements_to_points[element];
     auto const element_nodes = elements_to_element_nodes[element];
 
-    for (auto&& element_point : points_in_element)
+    for (auto&& element_point : points_in_support)
     {
-      hpc::position<double> avg_coord(0., 0., 0.);
       auto const point = cur_elem_points[element_point];
       auto&& point_support_nodes = nodes_in_support[point];
       for (auto&& n : nodes_in_element)
       {
         auto const cur_elem_node_offset = element_nodes[n];
         auto const node = element_nodes_to_nodes[cur_elem_node_offset];
-        avg_coord += nodes_to_x[node].load();
         support_nodes_to_nodes[point_support_nodes[n]] = node;
       }
-
-      avg_coord /= nodes_in_element.size();
-
-      auto min_node_centroid_dist = 1.0 / hpc::machine_epsilon<double>();
-      for (auto&& n : nodes_in_element)
-      {
-        auto cur_elem_node_offset = element_nodes[n];
-        auto node = element_nodes_to_nodes[cur_elem_node_offset];
-        auto node_centroid_dist = hpc::norm(nodes_to_x[node].load() - avg_coord);
-        min_node_centroid_dist = hpc::min(min_node_centroid_dist, node_centroid_dist);
-      }
-      mat_pts_to_x[point] = avg_coord;
-      mat_pts_to_h[point] = min_node_centroid_dist;
     }
   };
-
   hpc::for_each(hpc::device_policy(), st.elements, func);
 
   invert_otm_point_node_relations(st);
+
+  if (in.xp_transform)
+  {
+    in.xp_transform(st.points, st.points_to_point_nodes, st.point_nodes_to_nodes, st.x, st.xp);
+  }
+
+  auto const mat_pts_to_x = st.xp.begin();
+  auto const mat_pts_to_h = st.h_otm.begin();
+  auto const nodes_to_x = st.x.cbegin();
+  auto h_min_func = [=] HPC_DEVICE (point_index const point)
+  {
+    auto min_node_pt_dist = 1.0 / hpc::machine_epsilon<double>();
+    for (auto&& n : nodes_in_support[point])
+    {
+      auto node = support_nodes_to_nodes[n];
+      auto node_pt_dist = hpc::norm(nodes_to_x[node].load() - mat_pts_to_x[point].load());
+      min_node_pt_dist = hpc::min(min_node_pt_dist, node_pt_dist);
+    }
+    mat_pts_to_h[point] = min_node_pt_dist;
+  };
+  hpc::for_each(hpc::device_policy(), st.points, h_min_func);
 }
 
 }

--- a/v3/otm_tet2meshless.hpp
+++ b/v3/otm_tet2meshless.hpp
@@ -4,6 +4,6 @@ namespace lgr {
 
 class state;
 
-void convert_tet_mesh_to_meshless(state& st);
+void convert_tet_mesh_to_meshless(state& st, const input& in);
 
 }

--- a/v3/unit_tests/exodus.cpp
+++ b/v3/unit_tests/exodus.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <hpc_algorithm.hpp>
+#include <hpc_array.hpp>
 #include <hpc_execution.hpp>
 #include <hpc_index.hpp>
 #include <hpc_macros.hpp>
@@ -21,6 +22,7 @@ using elems_size_type = range_size_type<element_index>;
 using points_size_type = range_size_type<point_index>;
 using nodes_in_elem_size_type = range_size_type<node_in_element_index>;
 using nodes_in_support_size_type = range_size_type<point_node_index>;
+using point_nodes_size_type = range_size_type<node_point_index>;
 }
 
 TEST(exodus, readSimpleFile)
@@ -39,12 +41,74 @@ TEST(exodus, readSimpleFile)
   EXPECT_EQ(st.elements.size(), elems_size_type(12));
 }
 
-TEST(exodus, convertTetMeshToMeshfree) {
+void compute_material_points_as_element_centroids(hpc::counting_range<point_index> const points,
+    hpc::device_range_sum<point_node_index, point_index> const &points_to_point_nodes,
+    hpc::device_vector<node_index, point_node_index> const &point_nodes_to_nodes,
+    hpc::device_array_vector<hpc::position<double>, node_index> const &x,
+    hpc::device_array_vector<hpc::position<double>, point_index> &xp)
+{
+  auto pt_to_pt_nodes = points_to_point_nodes.cbegin();
+  auto pt_nodes_to_nodes = point_nodes_to_nodes.cbegin();
+  auto x_nodes = x.cbegin();
+  auto x_points = xp.begin();
+  auto point_func = [=] HPC_DEVICE(const point_index point)
+  {
+    auto const point_nodes = pt_to_pt_nodes[point];
+    hpc::position<double> avg_coord(0., 0., 0.);
+    for (auto&& point_node : point_nodes)
+    {
+      auto const node = pt_nodes_to_nodes[point_node];
+      avg_coord += x_nodes[node].load();
+    }
+    avg_coord /= point_nodes.size();
+
+    x_points[point] = avg_coord;
+  };
+  hpc::for_each(hpc::device_policy(), points, point_func);
+}
+
+auto collect_points_to_nodes_from_elements(state &st)
+{
+  const auto element_nodes_to_nodes = st.elements_to_nodes.cbegin();
+  const auto elements_to_element_nodes = st.elements * st.nodes_in_element;
+  const auto elements_to_points = st.elements * st.points_in_element;
+  const auto nodes_in_element = st.nodes_in_element;
+  const auto points_in_element = st.points_in_element;
+  hpc::device_vector<node_index, point_node_index> point_node_indices;
+  point_node_indices.resize(st.points.size() * st.nodes_in_element.size());
+  auto points_to_point_nodes = st.points * st.nodes_in_element;
+  auto points_to_nodes = point_node_indices.begin();
+  auto elem_func = [=](const element_index element) 
+  {
+    const auto element_nodes = elements_to_element_nodes[element];
+    const auto element_points = elements_to_points[element];
+    for (const auto point_ordinal: points_in_element)
+    {
+      auto point = element_points[point_ordinal];
+      auto point_nodes = points_to_point_nodes[point];
+      for (const auto node_ordinal: nodes_in_element)
+      {
+        const auto node = element_nodes_to_nodes[element_nodes[node_ordinal]];
+        const auto point_node = point_nodes[node_ordinal];
+        points_to_nodes[hpc::weaken(point_node)] = node;
+      }
+    }
+  }
+  ;
+  hpc::for_each(hpc::device_policy(), st.elements, elem_func);
+  return std::move(point_node_indices);
+}
+
+TEST(exodus, convertTetMeshToMeshfree)
+{
   material_index mat(1);
   material_index bnd(1);
   input in(mat, bnd);
   state st;
   in.element = MESHLESS;
+  in.otm_material_points_to_add_per_element = 1;
+
+  in.xp_transform = compute_material_points_as_element_centroids;
 
   int err_code = read_exodus_file("tets.g", in, st);
 
@@ -53,7 +117,7 @@ TEST(exodus, convertTetMeshToMeshfree) {
   EXPECT_EQ(st.points.size(), points_size_type(12));
   EXPECT_EQ(st.nodes_in_element.size(), nodes_in_elem_size_type(4));
 
-  convert_tet_mesh_to_meshless(st);
+  convert_tet_mesh_to_meshless(st, in);
 
   EXPECT_EQ(st.points_to_point_nodes.size(), st.points.size());
 
@@ -65,32 +129,10 @@ TEST(exodus, convertTetMeshToMeshfree) {
   };
   unit::test_for_each(hpc::device_policy(), st.points, check_points_func);
 
-  auto const element_nodes_to_nodes = st.elements_to_nodes.cbegin();
-  auto const elements_to_element_nodes = st.elements * st.nodes_in_element;
-  auto const elements_to_points = st.elements * st.points_in_element;
-  auto const nodes_in_element = st.nodes_in_element;
-  auto const points_in_element = st.points_in_element;
+  hpc::device_vector<node_index, point_node_index> point_node_indices =
+      collect_points_to_nodes_from_elements(st);
 
-  hpc::device_vector<node_index, point_node_index> point_node_indices;
-  point_node_indices.resize(st.points.size() * st.nodes_in_element.size());
-  auto points_to_point_nodes = st.points * st.nodes_in_element;
-  auto points_to_nodes = point_node_indices.begin();
-
-  auto elem_func = [=] HPC_DEVICE (element_index const element) {
-    auto const element_nodes = elements_to_element_nodes[element];
-    auto const element_points = elements_to_points[element];
-    for (auto const point_ordinal : points_in_element) {
-      auto point = element_points[point_ordinal];
-      auto point_nodes = points_to_point_nodes[point];
-      for (auto const node_ordinal : nodes_in_element) {
-        auto const node = element_nodes_to_nodes[element_nodes[node_ordinal]];
-        auto const point_node = point_nodes[node_ordinal];
-        points_to_nodes[hpc::weaken(point_node)] = node;
-      }
-    }
-  };
-  hpc::for_each(hpc::device_policy(), st.elements, elem_func);
-
+  auto points_to_nodes = point_node_indices.cbegin();
   auto supports = st.points_to_point_nodes.cbegin();
   auto support_nodes_to_nodes = st.point_nodes_to_nodes.cbegin();
   auto pt_func = DEVICE_TEST(point_index const point) {
@@ -101,4 +143,142 @@ TEST(exodus, convertTetMeshToMeshfree) {
     }
   };
   unit::test_for_each(hpc::device_policy(), st.points, pt_func);
+}
+
+HPC_ALWAYS_INLINE hpc::position<double>
+tetrahedron_local_to_global_coord(const hpc::array<hpc::position<double>, 4>& node_coords,
+    const hpc::position<double> &parametric_coord)
+{
+  return parametric_coord(0) * node_coords[0] + parametric_coord(1) * node_coords[1]
+      + parametric_coord(2) * node_coords[2]
+      + (1.0 - parametric_coord(0) - parametric_coord(1) - parametric_coord(2)) * node_coords[3];
+}
+
+struct tet_gauss_points_to_material_points
+{
+  tet_gauss_points_to_material_points(
+      const hpc::host_vector<hpc::position<double>, point_node_index> &gauss_pts) :
+      gauss_points(gauss_pts.size())
+  {
+    hpc::copy(gauss_pts, gauss_points);
+  }
+
+  void operator()(hpc::counting_range<point_index> const points,
+      hpc::device_range_sum<point_node_index, point_index> const &points_to_point_nodes,
+      hpc::device_vector<node_index, point_node_index> const &point_nodes_to_nodes,
+      hpc::device_array_vector<hpc::position<double>, node_index> const &x,
+      hpc::device_array_vector<hpc::position<double>, point_index> &xp)
+  {
+    auto pt_to_pt_nodes = points_to_point_nodes.cbegin();
+    auto pt_nodes_to_nodes = point_nodes_to_nodes.cbegin();
+    auto x_nodes = x.cbegin();
+    auto x_points = xp.begin();
+    auto gauss_pts = hpc::make_iterator_range(gauss_points.cbegin(), gauss_points.cend());
+    auto point_func = [=] HPC_DEVICE(const point_index point)
+    {
+      auto const point_nodes = pt_to_pt_nodes[point];
+      hpc::position<double> avg_coord(0., 0., 0.);
+      hpc::array<hpc::position<double>, 4> x;
+      assert(point_nodes.size() == 4);
+      for (int i = 0; i < 4; ++i)
+      {
+        auto const node = pt_nodes_to_nodes[point_nodes[i]];
+        x[i] = x_nodes[node].load();
+      }
+      for (auto gp : gauss_pts)
+      {
+        x_points[point] = tetrahedron_local_to_global_coord(x, gp);
+      }
+      avg_coord /= point_nodes.size();
+
+      x_points[point] = avg_coord;
+    };
+    hpc::for_each(hpc::device_policy(), points, point_func);
+  }
+
+  hpc::device_vector<hpc::position<double>, point_node_index> gauss_points;
+};
+
+TEST(exodus, convertTetMeshToMeshfreeInterpolateSingleMaterialPoint) {
+  material_index mat(1);
+  material_index bnd(1);
+  input in(mat, bnd);
+  state st;
+  in.element = MESHLESS;
+  in.otm_material_points_to_add_per_element = 1;
+
+  hpc::host_vector<hpc::position<double>, point_node_index> tet_gauss_pts(1, { 0.25, 0.25, 0.25 });
+  tet_gauss_points_to_material_points point_interpolator(tet_gauss_pts);
+  in.xp_transform = std::ref(point_interpolator);
+
+  int err_code = read_exodus_file("tets.g", in, st);
+
+  ASSERT_EQ(err_code, 0);
+
+  EXPECT_EQ(st.points.size(), points_size_type(12));
+  EXPECT_EQ(st.nodes_in_element.size(), nodes_in_elem_size_type(4));
+
+  convert_tet_mesh_to_meshless(st, in);
+
+  EXPECT_EQ(st.points_to_point_nodes.size(), st.points.size());
+
+  auto support_nodes = st.points_to_point_nodes.cbegin();
+  auto check_points_func = DEVICE_TEST(point_index const point)
+  {
+    auto point_support_node_range = support_nodes[point];
+    DEVICE_EXPECT_EQ(point_support_node_range.size(), nodes_in_support_size_type(4));
+  };
+  unit::test_for_each(hpc::device_policy(), st.points, check_points_func);
+
+  hpc::device_vector<node_index, point_node_index> point_node_indices =
+      collect_points_to_nodes_from_elements(st);
+
+  auto points_to_nodes = point_node_indices.cbegin();
+  auto supports = st.points_to_point_nodes.cbegin();
+  auto support_nodes_to_nodes = st.point_nodes_to_nodes.cbegin();
+  auto pt_func = DEVICE_TEST(point_index const point) {
+    auto point_support_nodes = supports[point];
+    for (auto&& n : point_support_nodes)
+    {
+      DEVICE_EXPECT_EQ(points_to_nodes[hpc::weaken(n)], support_nodes_to_nodes[n]);
+    }
+  };
+  unit::test_for_each(hpc::device_policy(), st.points, pt_func);
+}
+
+TEST(exodus, convertTetMeshToMeshfreeInterpolateMaterialPoints) {
+  material_index mat(1);
+  material_index bnd(1);
+  input in(mat, bnd);
+  state st;
+  in.element = MESHLESS;
+  in.otm_material_points_to_add_per_element = 4;
+
+  hpc::host_vector<hpc::position<double>, point_node_index> tet_gauss_pts(4);
+  tet_gauss_pts[0] = { 0.1381966011250105, 0.1381966011250105, 0.1381966011250105 };
+  tet_gauss_pts[1] = { 0.5854101966249685, 0.1381966011250105, 0.1381966011250105 };
+  tet_gauss_pts[2] = { 0.1381966011250105, 0.5854101966249685, 0.1381966011250105 };
+  tet_gauss_pts[3] = { 0.1381966011250105, 0.1381966011250105, 0.5854101966249685 };
+  tet_gauss_points_to_material_points point_interpolator(tet_gauss_pts);
+  in.xp_transform = std::ref(point_interpolator);
+
+  int err_code = read_exodus_file("tets.g", in, st);
+
+  ASSERT_EQ(err_code, 0);
+
+  EXPECT_EQ(st.points.size(), points_size_type(12));
+  EXPECT_EQ(st.nodes_in_element.size(), nodes_in_elem_size_type(4));
+
+  convert_tet_mesh_to_meshless(st, in);
+
+  EXPECT_EQ(st.points_to_point_nodes.size(), st.points.size());
+  EXPECT_EQ(st.xp.size(), st.points.size());
+
+  auto support_nodes = st.points_to_point_nodes.cbegin();
+  auto check_points_func = DEVICE_TEST(point_index const point)
+  {
+    auto point_support_node_range = support_nodes[point];
+    DEVICE_EXPECT_EQ(point_support_node_range.size(), nodes_in_support_size_type(4));
+  };
+  unit::test_for_each(hpc::device_policy(), st.points, check_points_func);
 }

--- a/v3/unit_tests/search.cpp
+++ b/v3/unit_tests/search.cpp
@@ -280,12 +280,15 @@ TEST_F(arborx_search, canDoIterativeSphereIntersectSearchOnExodusMesh)
   input in(mat, bnd);
   state st;
   in.element = MESHLESS;
+  in.otm_material_points_to_add_per_element = 1;
+
+  in.xp_transform = compute_material_points_as_element_centroids;
 
   int err_code = read_exodus_file("tets.g", in, st);
 
   ASSERT_EQ(err_code, 0);
 
-  convert_tet_mesh_to_meshless(st);
+  convert_tet_mesh_to_meshless(st, in);
 
   hpc::device_vector<node_index, point_node_index> points_to_supported_nodes_before_search(
       st.point_nodes_to_nodes.size());

--- a/v3/unit_tests/unit_device_util.hpp
+++ b/v3/unit_tests/unit_device_util.hpp
@@ -3,11 +3,19 @@
 #include <hpc_functional.hpp>
 #include <hpc_transform_reduce.hpp>
 
+#ifdef LGR_ENABLE_CUDA
 #define DEVICE_TEST(a) [=] HPC_DEVICE(a, int& num_fails)
 #define DEVICE_ASSERT_EQ(a, b) if (a != b) { ++num_fails; return; }
 #define DEVICE_EXPECT_EQ(a, b) if (a != b) { ++num_fails; }
 #define DEVICE_EXPECT_TRUE(a) if (!a) { ++num_fails; }
 #define DEVICE_EXPECT_FALSE(a) if (a) { ++num_fails; }
+#else
+#define DEVICE_TEST(a) [=] HPC_DEVICE(a)
+#define DEVICE_ASSERT_EQ(a, b) ASSERT_EQ(a, b)
+#define DEVICE_EXPECT_EQ(a, b) EXPECT_EQ(a, b)
+#define DEVICE_EXPECT_TRUE(a) EXPECT_TRUE(a)
+#define DEVICE_EXPECT_FALSE(a) EXPECT_FALSE(a)
+#endif
 
 namespace unit {
 
@@ -24,9 +32,14 @@ public:
 
   HPC_ALWAYS_INLINE HPC_DEVICE int operator()(typename Range::value_type i) const
   {
+#ifdef LGR_ENABLE_CUDA
     int num_fails = 0;
     func(i, num_fails);
     return num_fails;
+#else
+    func(i);
+    return 0;
+#endif
   }
 
 private:


### PR DESCRIPTION
…determine

  material point locations.  This uses an "xp_transform" function specified as
  part of input.  There is no default transformation (i.e., all points will be
  at the origin unless otherwise specified.)

  Refactor device unit testing utils to use regular GTest checking on the host
  for ease of debugging.