### PR TITLE
OTM: add test verifying search returns nearest neighbor

### DIFF
--- a/v3/otm_meshless.cpp
+++ b/v3/otm_meshless.cpp
@@ -48,7 +48,7 @@ void otm_initialize_velocity(state& s)
   auto const nodes_to_x = s.x.cbegin();
   auto const nodes_to_v = s.v.begin();
   auto const top_vel = hpc::speed<double>(10.0);
-  auto functor = [=] HPC_DEVICE (point_index const node) {
+  auto functor = [=] HPC_DEVICE (node_index const node) {
     auto const x = nodes_to_x[node].load();
     auto const vz = top_vel * x(2);
     nodes_to_v[node] = hpc::velocity<double>(0.0, 0.0, vz);

--- a/v3/otm_meshless.cpp
+++ b/v3/otm_meshless.cpp
@@ -261,7 +261,7 @@ void otm_update_reference(state& s) {
       auto const node = point_nodes_to_nodes[point_node];
       auto const u = nodes_to_u[node].load();
       auto const old_grad_N = point_nodes_to_grad_N[point_node].load();
-      F_incr = F_incr + outer_product(u, old_grad_N);
+      F_incr += outer_product(u, old_grad_N);
     }
     // TODO: Verify this is also true for OTM
     auto const F_inverse_transpose = transpose(inverse(F_incr));
@@ -572,19 +572,14 @@ void otm_initialize(input& in, state& s, std::string const& filename)
 HPC_NOINLINE inline void compute_min_neighbor_dist(state& s) {
   search_util::point_neighbors n;
   search::do_otm_point_nearest_point_search(s, n, 1);
+  hpc::fill(hpc::device_policy(), s.nearest_neighbor_dist, -1.0);
   search_util::compute_point_neighbor_squared_distances(s, n, s.nearest_neighbor_dist);
   assert( s.nearest_neighbor_dist.size() == s.points.size() );
-  auto const nearest_neighbors = n.entities_to_neighbors.cbegin();
   auto const neighbor_distances = s.nearest_neighbor_dist.begin();
   auto dist_func = [=] HPC_DEVICE (point_index const point) {
-                     auto const neighbor = nearest_neighbors[point];
-                     if (point < neighbor)
-                     {
-                       auto const dist = std::sqrt(neighbor_distances[point]);
-                       neighbor_distances[point] = dist;
-                       neighbor_distances[neighbor] = dist;
-                     }
-                   };
+    auto const dist = std::sqrt(neighbor_distances[point]);
+    neighbor_distances[point] = dist;
+  };
   hpc::for_each(hpc::device_policy(), s.points, dist_func);
 }
 

--- a/v3/unit_tests/search.cpp
+++ b/v3/unit_tests/search.cpp
@@ -374,6 +374,20 @@ TEST_F(distances_search, can_compute_nearest_and_farthest_node_to_node_from_sear
   check_single_tetrahedron_node_neighbor_squared_distances(s, n, nodes_to_neighbor_squared_distances);
 }
 
+TEST_F(distances_search, search_with_single_node_always_returns_nearest_node)
+{
+  state s;
+  tetrahedron_single_point(s);
+
+  node_neighbors n;
+  search::do_otm_node_nearest_node_search(s, n, 1);
+
+  hpc::device_vector<hpc::length<double>, node_index> nodes_to_neighbor_squared_distances;
+  compute_node_neighbor_squared_distances(s, n, nodes_to_neighbor_squared_distances);
+
+  check_single_tetrahedron_nearest_node_squared_distance(s, n, nodes_to_neighbor_squared_distances);
+}
+
 TEST_F(distances_search, can_compute_nearest_and_farthest_point_to_point_from_search)
 {
   state s;

--- a/v3/unit_tests/unit_otm_distance_util.hpp
+++ b/v3/unit_tests/unit_otm_distance_util.hpp
@@ -41,6 +41,25 @@ inline void check_single_tetrahedron_node_neighbor_squared_distances(const lgr::
   unit::test_for_each(hpc::device_policy(), s.nodes, check_func);
 }
 
+inline void check_single_tetrahedron_nearest_node_squared_distance(const lgr::state &s,
+    const lgr::search_util::node_neighbors &n,
+    hpc::device_vector<hpc::length<double>, lgr::node_index> &nodes_to_neighbor_squared_distances)
+{
+  ASSERT_EQ(nodes_to_neighbor_squared_distances.size(), 4);
+
+  auto n2n_distances = nodes_to_neighbor_squared_distances.cbegin();
+  auto n2n_neighbors = n.entities_to_neighbor_ordinals.cbegin();
+  auto check_func = DEVICE_TEST (lgr::node_index node)
+  {
+    constexpr hpc::length<double> expected = 1.0;
+    auto closest_neighbor = n2n_neighbors[node];
+    DEVICE_ASSERT_EQ(closest_neighbor.size(), 1);
+    auto const node_to_node_dist = n2n_distances[closest_neighbor[0]];
+    DEVICE_EXPECT_EQ(expected, node_to_node_dist);
+  };
+  unit::test_for_each(hpc::device_policy(), s.nodes, check_func);
+}
+
 inline void check_two_tetrahedron_point_neighbor_squared_distances(const lgr::state &s,
     const lgr::search_util::point_neighbors &n,
     hpc::device_vector<hpc::length<double>, lgr::point_index> &pts_to_neighbor_squared_distances)


### PR DESCRIPTION
@lxmota @btalami This test shows that for at least the single tet case, search returns the correct nearest neighboring node distance for timestep computation. We might expand testing to make sure the search returns the right distance even with a moving mesh?

Update: Removed assumption of search symmetry so that all points definitely get a distance value from their closest point. @lxmota Please test this with your PR?