### PR TITLE
OTM: collect boundary conditions into node sets and split position up…

### DIFF
--- a/v3/otm_meshless.cpp
+++ b/v3/otm_meshless.cpp
@@ -342,6 +342,32 @@ void otm_update_nodal_momentum(state& s) {
   hpc::for_each(hpc::device_policy(), s.nodes, functor);
 }
 
+inline void otm_enforce_boundary_conditions(state &s)
+{
+  auto const dt = s.dt;
+  auto const boundary_indices = s.boundaries;
+  auto const boundary_to_prescribed_v = s.prescribed_v.cbegin();
+  auto const boundary_to_prescribed_dof = s.prescribed_dof.cbegin();
+  auto const nodes_to_u = s.u.begin();
+  for (auto boundary_index : boundary_indices)
+  {
+    auto const v = boundary_to_prescribed_v[boundary_index].load();
+    auto const dof = boundary_to_prescribed_dof[boundary_index].load();
+    auto functor = [=] HPC_DEVICE (node_index const node)
+    {
+      auto disp = nodes_to_u[node].load();
+      if (dof(0) == 1)
+      { disp(0) = v(0) * dt;}
+      if (dof(1) == 1)
+      { disp(1) = v(1) * dt;}
+      if (dof(2) == 1)
+      { disp(2) = v(2) * dt;}
+      nodes_to_u[node] = disp;
+    };
+    hpc::for_each(hpc::device_policy(), s.node_sets[boundary_index], functor);
+  }
+}
+
 void otm_update_nodal_position(state& s) {
   auto const dt = s.dt;
   auto const dt_old = s.dt_old;
@@ -352,34 +378,26 @@ void otm_update_nodal_position(state& s) {
   auto const nodes_to_x = s.x.begin();
   auto const nodes_to_u = s.u.begin();
   auto const nodes_to_v = s.v.begin();
-  auto const nodes_to_domain = s.nodal_materials.cbegin();
-  auto const boundary_indices = s.boundaries;
-  auto const boundary_to_prescribed_v = s.prescribed_v.cbegin();
-  auto const boundary_to_prescribed_dof = s.prescribed_dof.cbegin();
-  for (auto boundary_index : boundary_indices) {
-    material_set const boundary(boundary_index);
-    auto const v = boundary_to_prescribed_v[boundary_index].load();
-    auto const dof = boundary_to_prescribed_dof[boundary_index].load();
-    auto functor = [=] HPC_DEVICE (node_index const node) {
-      auto const m = nodes_to_mass[node];
-      auto const lm = nodes_to_lm[node].load();
-      auto const f = nodes_to_f[node].load();
-      auto disp = (dt / m) * (lm + dt_avg * f);
-      auto const domain_set = nodes_to_domain[node];
-      if (domain_set.contains(boundary)) {
-        if (dof(0) == 1) {disp(0) = v(0) * dt;}
-        if (dof(1) == 1) {disp(1) = v(1) * dt;}
-        if (dof(2) == 1) {disp(2) = v(2) * dt;}
-      }
-      auto const velo = disp / dt;
-      auto x_old = nodes_to_x[node].load();
-      nodes_to_u[node] = disp;
-      auto x_new = x_old + disp;
-      nodes_to_x[node] = x_new;
-      nodes_to_v[node] = velo;
-    };
-    hpc::for_each(hpc::device_policy(), s.nodes, functor);
-  }
+  auto disp_functor = [=] HPC_DEVICE (node_index const node) {
+    auto const m = nodes_to_mass[node];
+    auto const lm = nodes_to_lm[node].load();
+    auto const f = nodes_to_f[node].load();
+    auto disp = (dt / m) * (lm + dt_avg * f);
+    nodes_to_u[node] = disp;
+  };
+  hpc::for_each(hpc::device_policy(), s.nodes, disp_functor);
+
+  otm_enforce_boundary_conditions(s);
+
+  auto coord_vel_update_functor = [=] HPC_DEVICE (node_index const node) {
+    auto disp = nodes_to_u[node].load();
+    auto const velo = disp / dt;
+    nodes_to_v[node] = velo;
+    auto x_old = nodes_to_x[node].load();
+    auto x_new = x_old + disp;
+    nodes_to_x[node] = x_new;
+  };
+  hpc::for_each(hpc::device_policy(), s.nodes, coord_vel_update_functor);
 }
 
 void otm_update_point_position(state& s)
@@ -560,6 +578,7 @@ void otm_initialize(input& in, state& s, std::string const& filename)
   hpc::fill(hpc::device_policy(), s.v, v0);
   hpc::fill(hpc::device_policy(), s.u, u0);
   otm_mark_boundary_domains(in, s);
+  collect_node_sets(in, s);
   otm_initialize_velocity(s);
   otm_initialize_point_volume(s);
   otm_update_shape_functions(s);


### PR DESCRIPTION
…dating into 3 parts:

  1. compute displacements
  2. enforce BCs
  3. update positions

Use existing infrastructure to collect boundary condition node sets.