### PR TITLE
Otm adapt

### DIFF
--- a/v3/CMakeLists.txt
+++ b/v3/CMakeLists.txt
@@ -55,6 +55,7 @@ set(LGR_SOURCES
     )
 
 set(OTM_SOURCES
+    otm_adapt.cpp
     otm_apps.cpp
     otm_meshless.cpp
     otm_distance.cpp

--- a/v3/hpc_algorithm.hpp
+++ b/v3/hpc_algorithm.hpp
@@ -70,7 +70,7 @@ HPC_NOINLINE void copy(cuda_policy, FromRange const& from, ToRange& to) {
   auto const first = from.begin();
   auto const d_first = to.begin();
   auto functor = [=] HPC_DEVICE (typename FromRange::size_type const i) {
-    d_first[i] = FromRange::value_type(first[i]);
+    d_first[i] = typename FromRange::value_type(first[i]);
   };
   int n = int(from.size());
   thrust::counting_iterator<int> new_first(0);

--- a/v3/hpc_numeric.hpp
+++ b/v3/hpc_numeric.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <hpc_transform_reduce.hpp>
+#include <hpc_algorithm.hpp>
+#include <hpc_functional.hpp>
+#include <hpc_range.hpp>
 
 #ifdef HPC_CUDA
 #include <thrust/execution_policy.h>

--- a/v3/lgr_adapt.cpp
+++ b/v3/lgr_adapt.cpp
@@ -1,3 +1,4 @@
+#include <hpc_functional.hpp>
 #include <lgr_state.hpp>
 #include <lgr_input.hpp>
 #include <lgr_adapt.hpp>

--- a/v3/lgr_adapt.cpp
+++ b/v3/lgr_adapt.cpp
@@ -499,7 +499,6 @@ HPC_NOINLINE inline void choose_triangle_adapt(state const& s, adapt_state& a)
     if (op == cavity_op::NONE) {
       return;
     }
-    node_index const target_node = nodes_to_other_nodes[node];
     double const criteria = nodes_to_criteria[node];
     for (auto const node_element : nodes_to_node_elements[node]) {
       element_index const element = node_elements_to_elements[node_element];
@@ -535,6 +534,7 @@ HPC_NOINLINE inline void choose_triangle_adapt(state const& s, adapt_state& a)
     } else if (op == cavity_op::COLLAPSE) {
       edge_element_count = element_index(0);
     }
+    node_index const target_node = nodes_to_other_nodes[node];
     for (auto const node_element : nodes_to_node_elements[node]) {
       element_index const element = node_elements_to_elements[node_element];
       auto const element_nodes = elements_to_element_nodes[element];

--- a/v3/lgr_adapt.cpp
+++ b/v3/lgr_adapt.cpp
@@ -5,6 +5,7 @@
 #include <lgr_element_specific_inline.hpp>
 #include <lgr_print.hpp>
 #include <lgr_meshing.hpp>
+#include <lgr_adapt_util.hpp>
 
 #include <iostream>
 #include <iomanip>
@@ -725,23 +726,6 @@ HPC_NOINLINE inline void apply_triangle_adapt(state const& s, adapt_state& a)
   hpc::for_each(hpc::device_policy(), s.nodes, functor);
 }
 
-template <class Index>
-HPC_NOINLINE void project(
-    hpc::counting_range<Index> const old_things,
-    hpc::device_vector<Index, Index> const& old_things_to_new_things_in,
-    hpc::device_vector<Index, Index>& new_things_to_old_things_in) {
-  auto const old_things_to_new_things = old_things_to_new_things_in.cbegin();
-  auto const new_things_to_old_things = new_things_to_old_things_in.begin();
-  auto functor = [=] HPC_DEVICE (Index const old_thing) {
-    Index first = old_things_to_new_things[old_thing];
-    Index const last = old_things_to_new_things[old_thing + Index(1)];
-    for (; first < last; ++first) {
-      new_things_to_old_things[first] = old_thing;
-    }
-  };
-  hpc::for_each(hpc::device_policy(), old_things, functor);
-}
-
 HPC_NOINLINE inline void transfer_same_connectivity(state const& s, adapt_state& a) {
   auto const new_elements_to_element_nodes = a.new_elements * s.nodes_in_element;
   auto const old_elements_to_element_nodes = s.elements * s.nodes_in_element;
@@ -832,29 +816,10 @@ HPC_NOINLINE inline void transfer_nodal_energy(input const& in, adapt_state cons
 }
 
 template <class Range>
-HPC_NOINLINE void interpolate_nodal_data(adapt_state const& a, Range& data) {
-  using value_type = typename Range::value_type;
-  Range new_data(a.new_nodes.size());
-  auto const old_nodes_to_data = data.cbegin();
-  auto const new_nodes_to_data = new_data.begin();
-  auto const new_nodes_to_old_nodes = a.new_nodes_to_old_nodes.cbegin();
-  auto const new_nodes_are_same = a.new_nodes_are_same.cbegin();
-  auto const interpolate_from = a.interpolate_from.cbegin();
-  auto functor = [=] HPC_DEVICE (node_index const new_node) {
-    if (new_nodes_are_same[new_node]) {
-      node_index const old_node = new_nodes_to_old_nodes[new_node];
-      new_nodes_to_data[new_node] = value_type(old_nodes_to_data[old_node]);
-    } else {
-      auto const pair = interpolate_from[new_node].load();
-      node_index const left = pair[0];
-      node_index const right = pair[1];
-      new_nodes_to_data[new_node] = 0.5 * (
-          value_type(old_nodes_to_data[left])
-        + value_type(old_nodes_to_data[right]));
-    }
-  };
-  hpc::for_each(hpc::device_policy(), a.new_nodes, functor);
-  data = std::move(new_data);
+HPC_NOINLINE void interpolate_nodal_data(adapt_state const &a, Range &data)
+{
+  interpolate_data(a.new_nodes, a.new_nodes_to_old_nodes, a.new_nodes_are_same, a.interpolate_from,
+      data);
 }
 
 bool adapt(input const& in, state& s) {

--- a/v3/lgr_adapt_util.hpp
+++ b/v3/lgr_adapt_util.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <hpc_array.hpp>
 #include <hpc_execution.hpp>
 #include <hpc_macros.hpp>
 #include <hpc_range.hpp>
 #include <hpc_vector.hpp>
+#include <hpc_array_vector.hpp>
 
 namespace lgr {
 
@@ -31,6 +33,8 @@ HPC_NOINLINE void interpolate_data(const hpc::counting_range<Index> &new_entitie
     const hpc::device_array_vector<hpc::array<Index, 2, int>, Index> &interpolate_from_entities,
     Range &data)
 {
+  static_assert(std::is_same<Index, typename Range::size_type>::value,
+      "data range incompatible with Index");
   using value_type = typename Range::value_type;
   Range new_data(new_entities.size());
   auto const old_nodes_to_data = data.cbegin();

--- a/v3/lgr_adapt_util.hpp
+++ b/v3/lgr_adapt_util.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <hpc_execution.hpp>
+#include <hpc_macros.hpp>
+#include <hpc_range.hpp>
+#include <hpc_vector.hpp>
+
+namespace lgr {
+
+template <class Index>
+HPC_NOINLINE inline void project(
+    hpc::counting_range<Index> const old_things,
+    hpc::device_vector<Index, Index> const& old_things_to_new_things_in,
+    hpc::device_vector<Index, Index>& new_things_to_old_things_in) {
+  auto const old_things_to_new_things = old_things_to_new_things_in.cbegin();
+  auto const new_things_to_old_things = new_things_to_old_things_in.begin();
+  auto functor = [=] HPC_DEVICE (Index const old_thing) {
+    Index first = old_things_to_new_things[old_thing];
+    Index const last = old_things_to_new_things[old_thing + Index(1)];
+    for (; first < last; ++first) {
+      new_things_to_old_things[first] = old_thing;
+    }
+  };
+  hpc::for_each(hpc::device_policy(), old_things, functor);
+}
+
+template<class Index, class Range>
+HPC_NOINLINE void interpolate_data(const hpc::counting_range<Index> &new_entities,
+    const hpc::device_vector<Index, Index> &new_to_old,
+    const hpc::device_vector<bool, Index> &new_entities_are_same,
+    const hpc::device_array_vector<hpc::array<Index, 2, int>, Index> &interpolate_from_entities,
+    Range &data)
+{
+  using value_type = typename Range::value_type;
+  Range new_data(new_entities.size());
+  auto const old_nodes_to_data = data.cbegin();
+  auto const new_nodes_to_data = new_data.begin();
+  auto const new_nodes_to_old_nodes = new_to_old.cbegin();
+  auto const new_nodes_are_same = new_entities_are_same.cbegin();
+  auto const interpolate_from = interpolate_from_entities.cbegin();
+  auto functor = [=] HPC_DEVICE (Index const i)
+  {
+    if (new_nodes_are_same[i])
+    {
+      Index const old_node = new_nodes_to_old_nodes[i];
+      new_nodes_to_data[i] = value_type(old_nodes_to_data[old_node]);
+    } else
+    {
+      auto const pair = interpolate_from[i].load();
+      Index const left = pair[0];
+      Index const right = pair[1];
+      new_nodes_to_data[i] = 0.5 * (
+          value_type(old_nodes_to_data[left])
+          + value_type(old_nodes_to_data[right]));
+    }
+  };
+  hpc::for_each(hpc::device_policy(), new_entities, functor);
+  data = std::move(new_data);
+}
+
+}
+
+

--- a/v3/lgr_input.hpp
+++ b/v3/lgr_input.hpp
@@ -129,6 +129,8 @@ class input {
   bool enable_e_averaging = false;
   bool enable_p_averaging = false;
   bool enable_adapt = false;
+  hpc::length<double> max_node_neighbor_distance {1.0};
+  hpc::length<double> max_point_neighbor_distance {1.0};
   std::function<
     void(hpc::counting_range<node_index> const,
         hpc::device_array_vector<hpc::position<double>, node_index> const&,

--- a/v3/lgr_state.hpp
+++ b/v3/lgr_state.hpp
@@ -88,7 +88,8 @@ class state {
   hpc::device_array_vector<hpc::position<double>, point_index> xp; // current point positions
   hpc::device_array_vector<hpc::acceleration<double>, point_index> b; // acceleration corresponding to body force, mostly for weight
   hpc::device_vector<hpc::length<double>, point_index> h_otm; // characteristic length, used for max-ent functions
-  hpc::device_vector<hpc::length<double>, point_index> nearest_neighbor_dist; // distance to nearest point neighbor
+  hpc::device_vector<hpc::length<double>, point_index> nearest_point_neighbor_dist; // distance to nearest point neighbor
+  hpc::device_vector<hpc::length<double>, point_index> nearest_node_neighbor_dist; // distance to nearest point neighbor
   hpc::device_vector<hpc::energy_density<double>, point_node_index> potential_density; // Helmholtz energy density
   hpc::host_array_vector<hpc::velocity<double>, material_index> prescribed_v;
   hpc::host_array_vector<hpc::vector3<int>, material_index> prescribed_dof;
@@ -99,6 +100,8 @@ class state {
   bool use_penalty_contact{false};
   bool use_custom_initial_support_size{false};
   node_in_element_index initial_support_size{0};
+  hpc::length<double> min_point_neighbor_dist;
+  hpc::length<double> min_node_neighbor_dist;
 
   // For plasticity
   hpc::device_array_vector<hpc::deformation_gradient<double>, point_index> Fp_total; // plastic deformation gradient since simulation start

--- a/v3/otm_adapt.cpp
+++ b/v3/otm_adapt.cpp
@@ -1,5 +1,12 @@
+#include <hpc_execution.hpp>
+#include <hpc_numeric.hpp>
+#include <lgr_adapt_util.hpp>
+#include <lgr_input.hpp>
 #include <lgr_state.hpp>
 #include <otm_adapt.hpp>
+#include <otm_adapt_util.hpp>
+#include <otm_search.hpp>
+#include <iostream>
 
 namespace lgr {
 
@@ -24,6 +31,62 @@ otm_adapt_state::otm_adapt_state(state const &s) :
     new_points(point_index(0)),
     new_nodes(node_index(0))
 {
+}
+
+namespace {
+
+template<typename Index>
+void resize_and_project_adapt_data(const hpc::counting_range<Index> &old_range,
+    const hpc::device_vector<Index, Index> &new_counts, hpc::counting_range<Index> &new_range,
+    hpc::device_vector<Index, Index> &old_to_new, hpc::device_vector<bool, Index> &new_are_same,
+    hpc::device_array_vector<hpc::array<Index, 2, int>, Index> &interpolate_from,
+    hpc::device_vector<Index, Index> &new_to_old)
+{
+  auto const num_new = hpc::reduce(hpc::device_policy(), new_counts, Index(0));
+  hpc::offset_scan(hpc::device_policy(), new_counts, old_to_new);
+  new_range.resize(num_new);
+  new_to_old.resize(num_new);
+  new_are_same.resize(num_new);
+  interpolate_from.resize(num_new);
+  project(old_range, old_to_new, new_to_old);
+}
+
+}
+
+bool otm_adapt(const input& in, state& s)
+{
+  otm_adapt_state a(s);
+
+  evaluate_node_adapt(s, a, in.max_node_neighbor_distance);
+  evaluate_point_adapt(s, a, in.max_point_neighbor_distance);
+  choose_node_adapt(s, a);
+  choose_point_adapt(s, a);
+  auto const num_chosen_nodes = get_num_chosen_for_adapt(a.node_op);
+  auto const num_chosen_points = get_num_chosen_for_adapt(a.point_op);
+
+  if (num_chosen_nodes == 0 && num_chosen_points == 0) return false;
+
+  if (in.output_to_command_line)
+  {
+    std::cout << "adapting " << num_chosen_nodes << " nodes and " << num_chosen_points << " points" << std::endl;
+  }
+
+  resize_and_project_adapt_data(s.nodes, a.node_counts, a.new_nodes, a.old_nodes_to_new_nodes,
+      a.new_nodes_are_same, a.interpolate_from_nodes, a.new_nodes_to_old_nodes);
+  resize_and_project_adapt_data(s.points, a.point_counts, a.new_points, a.old_points_to_new_points,
+      a.new_points_are_same, a.interpolate_from_points, a.new_points_to_old_points);
+
+  apply_node_adapt(s, a);
+  apply_point_adapt(s, a);
+  interpolate_nodal_data(a, s.x);
+  interpolate_point_data(a, s.xp);
+  interpolate_point_data(a, s.h_otm);
+  s.nodes = a.new_nodes;
+  s.points = a.new_points;
+
+  search::do_otm_iterative_point_support_search(s, 4);
+
+  return true;
 }
 
 }

--- a/v3/otm_adapt.cpp
+++ b/v3/otm_adapt.cpp
@@ -1,0 +1,29 @@
+#include <lgr_state.hpp>
+#include <otm_adapt.hpp>
+
+namespace lgr {
+
+otm_adapt_state::otm_adapt_state(state const &s) :
+    node_criteria(s.nodes.size()),
+    point_criteria(s.points.size()),
+    other_node(s.nodes.size()),
+    other_point(s.points.size()),
+    node_op(s.nodes.size()),
+    point_op(s.points.size()),
+    point_counts(s.points.size()),
+    node_counts(s.nodes.size()),
+    old_points_to_new_points(s.points.size() + point_index(1)),
+    old_nodes_to_new_nodes(s.nodes.size() + node_index(1)),
+    new_points_to_old_points(),
+    new_nodes_to_old_nodes(),
+    new_point_nodes_to_nodes(),
+    new_points_are_same(),
+    new_nodes_are_same(),
+    interpolate_from_nodes(),
+    interpolate_from_points(),
+    new_points(point_index(0)),
+    new_nodes(node_index(0))
+{
+}
+
+}

--- a/v3/otm_adapt.hpp
+++ b/v3/otm_adapt.hpp
@@ -69,6 +69,7 @@ struct maxent_interpolator
 enum adapt_op {
   NONE,
   SPLIT,
+  COLLAPSE,
 };
 
 struct otm_adapt_state {

--- a/v3/otm_adapt.hpp
+++ b/v3/otm_adapt.hpp
@@ -66,6 +66,8 @@ struct maxent_interpolator
 
 #endif
 
+bool otm_adapt(const input& in, state& s);
+
 enum adapt_op {
   NONE,
   SPLIT,

--- a/v3/otm_adapt.hpp
+++ b/v3/otm_adapt.hpp
@@ -1,12 +1,26 @@
 #pragma once
 
+#include <hpc_array.hpp>
+#include <hpc_array_traits.hpp>
 #include <hpc_array_vector.hpp>
 #include <hpc_dimensional.hpp>
+#include <hpc_macros.hpp>
+#include <hpc_matrix3x3.hpp>
+#include <hpc_quaternion.hpp>
+#include <hpc_range.hpp>
+#include <hpc_symmetric3x3.hpp>
 #include <hpc_vector.hpp>
 #include <hpc_vector3.hpp>
 #include <lgr_mesh_indices.hpp>
+#include <cmath>
 
 namespace lgr {
+class state;
+}
+
+namespace lgr {
+
+#if 0
 
 struct maxent_interpolator
 {
@@ -32,7 +46,7 @@ struct maxent_interpolator
       if (iter >= max_iter) HPC_ERROR_EXIT("Exceeded maximum iterations.");
       hpc::position<double> R(0.0, 0.0, 0.0);
       auto dRdmu = jacobian::zero();
-      for (auto & source : sources) {
+      for (auto source : sources) {
         auto const r = source - target;
         auto const rr = hpc::inner_product(r, r);
         auto const mur = hpc::inner_product(mu, r);
@@ -48,6 +62,37 @@ struct maxent_interpolator
       ++iter;
     }
   }
+};
+
+#endif
+
+enum adapt_op {
+  NONE,
+  SPLIT,
+};
+
+struct otm_adapt_state {
+  hpc::device_vector<hpc::length<double>, node_index> node_criteria;
+  hpc::device_vector<hpc::length<double>, node_index> point_criteria;
+  hpc::device_vector<node_index, node_index> other_node;
+  hpc::device_vector<point_index, point_index> other_point;
+  hpc::device_vector<adapt_op, node_index> node_op;
+  hpc::device_vector<adapt_op, point_index> point_op;
+  hpc::device_vector<point_index, point_index> point_counts;
+  hpc::device_vector<node_index, node_index> node_counts;
+  hpc::device_vector<point_index, point_index> old_points_to_new_points;
+  hpc::device_vector<node_index, node_index> old_nodes_to_new_nodes;
+  hpc::device_vector<point_index, point_index> new_points_to_old_points;
+  hpc::device_vector<node_index, node_index> new_nodes_to_old_nodes;
+  hpc::device_vector<node_index, point_node_index> new_point_nodes_to_nodes;
+  hpc::device_vector<bool, point_index> new_points_are_same;
+  hpc::device_vector<bool, node_index> new_nodes_are_same;
+  hpc::device_array_vector<hpc::array<node_index, 2, int>, node_index> interpolate_from_nodes;
+  hpc::device_array_vector<hpc::array<point_index, 2, int>, point_index> interpolate_from_points;
+  hpc::counting_range<point_index> new_points;
+  hpc::counting_range<node_index> new_nodes;
+
+  otm_adapt_state(state const&);
 };
 
 } // namespace lgr

--- a/v3/otm_adapt_util.hpp
+++ b/v3/otm_adapt_util.hpp
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <hpc_array.hpp>
+#include <hpc_array_vector.hpp>
+#include <hpc_dimensional.hpp>
+#include <hpc_execution.hpp>
+#include <hpc_macros.hpp>
+#include <hpc_range.hpp>
+#include <hpc_vector.hpp>
+#include <lgr_state.hpp>
+#include <otm_adapt.hpp>
+#include <otm_distance.hpp>
+#include <otm_search.hpp>
+#include <otm_search_util.hpp>
+#include <cassert>
+
+namespace lgr {
+
+template<typename Index>
+HPC_NOINLINE inline void evaluate_adapt(const search_util::nearest_neighbors<Index> &n,
+    const hpc::counting_range<Index> &range,
+    const hpc::length<double> nearest_criterion,
+    const hpc::device_vector<hpc::length<double>, Index>& criteria,
+    hpc::device_vector<Index, Index> &other_entities,
+    hpc::device_vector<adapt_op, Index>& adapt_ops)
+{
+  assert(criteria.size() == range.size());
+  auto others = other_entities.begin();
+  auto ops = adapt_ops.begin();
+  auto neighbor_ords = n.entities_to_neighbor_ordinals.cbegin();
+  auto neighbors = n.entities_to_neighbors.cbegin();
+  auto crit = criteria.cbegin();
+  auto func = [=] HPC_DEVICE (const Index i)
+  {
+    if (crit[i] > nearest_criterion)
+    {
+      auto neighbor_range = neighbor_ords[i];
+      assert(neighbor_range.size() == 1);
+      others[i] = neighbors[neighbor_range[0]];
+      ops[i] = adapt_op::SPLIT;
+    } else
+    {
+      others[i] = Index(-1);
+      ops[i] = adapt_op::NONE;
+    }
+  };
+  hpc::for_each(hpc::device_policy(), range, func);
+}
+
+HPC_NOINLINE inline void evaluate_node_adapt(const state& s, otm_adapt_state& a,
+    const hpc::length<double> min_dist)
+{
+  search_util::node_neighbors n;
+  search::do_otm_node_nearest_node_search(s, n, 1);
+  compute_node_neighbor_squared_distances(s, n, a.node_criteria);
+  evaluate_adapt(n, s.nodes, min_dist, a.node_criteria, a.other_node, a.node_op);
+}
+
+HPC_NOINLINE inline void evaluate_point_adapt(const state& s, otm_adapt_state& a,
+    const hpc::length<double> min_dist)
+{
+  search_util::point_neighbors n;
+  search::do_otm_point_nearest_point_search(s, n, 1);
+  compute_point_neighbor_squared_distances(s, n, a.point_criteria);
+  evaluate_adapt(n, s.points, min_dist, a.point_criteria, a.other_point, a.point_op);
+}
+
+template <typename Index>
+HPC_NOINLINE inline void choose_adapt(const hpc::counting_range<Index>& range,
+    const hpc::device_vector<Index, Index>& other_entity,
+    hpc::device_vector<adapt_op, Index>& entity_ops,
+    hpc::device_vector<Index, Index>& counts) {
+  hpc::fill(hpc::device_policy(), counts, Index(1));
+  auto others = other_entity.cbegin();
+  auto ops = entity_ops.begin();
+  auto new_counts = counts.begin();
+  auto func = [=] HPC_DEVICE (const Index i)
+  {
+    auto op = ops[i];
+    if (op == adapt_op::NONE) return;
+    auto target = others[i];
+    auto target_of_target = others[target];
+    if (target_of_target == i && target < i)
+    {
+      // symmetric nearest neighbor relation
+      ops[i] = adapt_op::NONE;
+      return;
+    }
+    Index entity_count(-100);
+    if (op == adapt_op::SPLIT)
+    {
+      entity_count = Index(2);
+    } else if (op == adapt_op::COLLAPSE)
+    {
+      entity_count = Index(0);
+    }
+    new_counts[i] = entity_count;
+  };
+  hpc::for_each(hpc::device_policy(), range, func);
+}
+
+HPC_NOINLINE inline void choose_node_adapt(const state& s, otm_adapt_state &a)
+{
+  choose_adapt(s.nodes, a.other_node, a.node_op, a.node_counts);
+}
+
+HPC_NOINLINE inline void choose_point_adapt(const state& s, otm_adapt_state &a)
+{
+  choose_adapt(s.points, a.other_point, a.point_op, a.point_counts);
+}
+
+template<typename Index>
+HPC_NOINLINE inline int get_num_chosen_for_adapt(const hpc::device_vector<adapt_op, Index> &ops)
+{
+  auto const num_chosen = hpc::transform_reduce(hpc::device_policy(), ops, int(0), hpc::plus<int>(),
+      [] HPC_DEVICE (adapt_op const op)
+      { return op == adapt_op::NONE ? 0 : 1;});
+  return num_chosen;
+}
+
+template <typename Index>
+HPC_NOINLINE inline void apply_adapt(const hpc::counting_range<Index>& range,
+    const hpc::device_vector<adapt_op, Index>& ops,
+    const hpc::device_vector<Index, Index>& others,
+    hpc::device_vector<Index, Index>& old_to_new,
+    hpc::device_vector<bool, Index>& new_are_same,
+    hpc::device_array_vector<hpc::array<Index, 2, int>, Index>& interpolate_from)
+{
+  hpc::fill(hpc::device_policy(), new_are_same, true);
+  auto const entity_to_op = ops.cbegin();
+  auto const entity_to_other = others.cbegin();
+  auto old_to_new_entities = old_to_new.begin();
+  auto new_entities_are_same = new_are_same.begin();
+  auto interpolate_from_entities = interpolate_from.begin();
+  auto func = [=] HPC_DEVICE (Index const i)
+  {
+    auto op = entity_to_op[i];
+    if (op == adapt_op::NONE) return;
+    auto const target = entity_to_other[i];
+    if (op == adapt_op::SPLIT)
+    {
+      auto const new_entity = old_to_new_entities[i];
+      auto const split_entity = new_entity + Index(1);
+      new_entities_are_same[split_entity] = false;
+      hpc::array<Index, 2, int> interp_from;
+      interp_from[0] = i;
+      interp_from[1] = target;
+      interpolate_from_entities[split_entity] = interp_from;
+    }
+  };
+  hpc::for_each(hpc::device_policy(), range, func);
+
+}
+
+HPC_NOINLINE inline void apply_node_adapt(const state &s, otm_adapt_state &a)
+{
+  apply_adapt(s.nodes, a.node_op, a.other_node, a.old_nodes_to_new_nodes, a.new_nodes_are_same,
+      a.interpolate_from_nodes);
+}
+
+HPC_NOINLINE inline void apply_point_adapt(const state& s, otm_adapt_state &a)
+{
+  apply_adapt(s.points, a.point_op, a.other_point, a.old_points_to_new_points, a.new_points_are_same,
+      a.interpolate_from_points);
+}
+
+template<class Range>
+HPC_NOINLINE inline void interpolate_nodal_data(const otm_adapt_state &a, Range &data)
+{
+  interpolate_data(a.new_nodes, a.new_nodes_to_old_nodes, a.new_nodes_are_same,
+      a.interpolate_from_nodes, data);
+}
+
+template<class Range>
+HPC_NOINLINE inline void interpolate_point_data(const otm_adapt_state &a, Range &data)
+{
+  interpolate_data(a.new_points, a.new_points_to_old_points, a.new_points_are_same,
+      a.interpolate_from_points, data);
+}
+
+}
+

--- a/v3/otm_distance.cpp
+++ b/v3/otm_distance.cpp
@@ -1,6 +1,8 @@
 #include <hpc_execution.hpp>
 #include <hpc_macros.hpp>
 #include <otm_distance.hpp>
+#include <hpc_array_vector.hpp>
+#include <hpc_dimensional.hpp>
 
 namespace lgr {
 namespace search_util {

--- a/v3/otm_meshless.cpp
+++ b/v3/otm_meshless.cpp
@@ -750,6 +750,12 @@ void otm_run(input const& in, state& s)
       if (s.n >= s.num_time_steps) continue;
       otm_time_integrator_step(in, s);
       if (in.enable_adapt && (s.n % 10 == 0)) {
+        for (int i=0; i<4; ++i)
+        {
+          otm_adapt(in, s);
+          update_min_nearest_neighbor_distances(s);
+          otm_allocate_state(in, s);
+        }
       }
     }
   } else {

--- a/v3/otm_meshless.cpp
+++ b/v3/otm_meshless.cpp
@@ -522,7 +522,8 @@ void otm_allocate_state(input const& in, state& s) {
   s.f.resize(num_nodes);
   s.rho.resize(num_points);
   s.b.resize(num_points);
-  s.nearest_neighbor_dist.resize(num_points);
+  s.nearest_point_neighbor_dist.resize(num_points);
+  if (in.enable_adapt) s.nearest_node_neighbor_dist.resize(num_nodes);
   s.material_mass.resize(num_materials);
   for (auto& mm : s.material_mass) mm.resize(num_nodes);
   s.mass.resize(num_nodes);
@@ -563,10 +564,6 @@ void otm_allocate_state(input const& in, state& s) {
     }
   }
   s.material.resize(num_elements);
-  if (in.enable_adapt) {
-    s.quality.resize(num_elements);
-    s.h_adapt.resize(num_nodes);
-  }
   s.nodal_materials.resize(num_nodes);
   s.prescribed_v.resize(num_boundaries + num_materials);
   s.prescribed_dof.resize(num_boundaries + num_materials);
@@ -584,18 +581,49 @@ void otm_initialize(input& in, state& s)
   otm_update_nodal_mass(s);
 }
 
-HPC_NOINLINE inline void compute_min_neighbor_dist(state& s) {
+namespace {
+
+template <typename Index>
+HPC_NOINLINE inline void compute_sqrt_nearest_neighbor_distances(const hpc::counting_range<Index>& range,
+    hpc::device_vector<hpc::length<double>, Index>& dists)
+{
+  assert( dists.size() == range.size() );
+  auto const neighbor_distances = dists.begin();
+  auto dist_func = [=] HPC_DEVICE (Index const i) {
+    auto const dist = std::sqrt(neighbor_distances[i]);
+    neighbor_distances[i] = dist;
+  };
+  hpc::for_each(hpc::device_policy(), range, dist_func);
+}
+
+}
+
+HPC_NOINLINE inline void update_nearest_point_neighbor_distances(state& s) {
   search_util::point_neighbors n;
   search::do_otm_point_nearest_point_search(s, n, 1);
-  hpc::fill(hpc::device_policy(), s.nearest_neighbor_dist, -1.0);
-  search_util::compute_point_neighbor_squared_distances(s, n, s.nearest_neighbor_dist);
-  assert( s.nearest_neighbor_dist.size() == s.points.size() );
-  auto const neighbor_distances = s.nearest_neighbor_dist.begin();
-  auto dist_func = [=] HPC_DEVICE (point_index const point) {
-    auto const dist = std::sqrt(neighbor_distances[point]);
-    neighbor_distances[point] = dist;
-  };
-  hpc::for_each(hpc::device_policy(), s.points, dist_func);
+  hpc::fill(hpc::device_policy(), s.nearest_point_neighbor_dist, -1.0);
+  search_util::compute_point_neighbor_squared_distances(s, n, s.nearest_point_neighbor_dist);
+  compute_sqrt_nearest_neighbor_distances(s.points, s.nearest_point_neighbor_dist);
+}
+
+HPC_NOINLINE inline void update_nearest_node_neighbor_distances(state& s) {
+  search_util::node_neighbors n;
+  search::do_otm_node_nearest_node_search(s, n, 1);
+  hpc::fill(hpc::device_policy(), s.nearest_node_neighbor_dist, -1.0);
+  search_util::compute_node_neighbor_squared_distances(s, n, s.nearest_node_neighbor_dist);
+  compute_sqrt_nearest_neighbor_distances(s.nodes, s.nearest_node_neighbor_dist);
+}
+
+HPC_NOINLINE inline void update_min_nearest_neighbor_distances(state &s)
+{
+  // TODO compute a relative change in distance as a metric...average?
+  hpc::length<double> const init = std::numeric_limits<double>::max();
+  s.min_node_neighbor_dist = hpc::transform_reduce(hpc::device_policy(),
+      s.nearest_node_neighbor_dist, init, hpc::minimum<hpc::length<double>>(),
+      hpc::identity<hpc::length<double>>());
+  s.min_point_neighbor_dist = hpc::transform_reduce(hpc::device_policy(),
+      s.nearest_point_neighbor_dist, init, hpc::minimum<hpc::length<double>>(),
+      hpc::identity<hpc::length<double>>());
 }
 
 HPC_NOINLINE inline hpc::energy<double> compute_kinetic_energy(const state& s) {
@@ -625,10 +653,10 @@ HPC_NOINLINE inline hpc::energy<double> compute_free_energy(const state& s) {
 }
 
 HPC_NOINLINE inline void update_point_dt(state& s) {
-  compute_min_neighbor_dist(s);
+  update_nearest_point_neighbor_distances(s);
   auto const points_to_c = s.c.cbegin();
   auto const points_to_dt = s.element_dt.begin();
-  auto const points_to_neighbor_dist = s.nearest_neighbor_dist.cbegin();
+  auto const points_to_neighbor_dist = s.nearest_point_neighbor_dist.cbegin();
   auto functor = [=] HPC_DEVICE (point_index const point) {
                    auto const h_min = points_to_neighbor_dist[point];
                    auto const c = points_to_c[point];
@@ -649,7 +677,8 @@ void otm_update_time_step(state& s)
 void otm_update_time(input const& in, state& s)
 {
   s.dt_old = s.dt;
-  if (in.use_constant_dt == true) {
+  if (in.use_constant_dt == true)
+  {
     auto const fp_n = static_cast<double>(s.n);
     auto const fp_np1 = static_cast<double>(s.n + 1);
     auto const fp_N = static_cast<double>(s.num_time_steps);
@@ -657,10 +686,22 @@ void otm_update_time(input const& in, state& s)
     auto const new_time = fp_np1 / fp_N * in.end_time;
     s.max_stable_dt = s.dt = new_time - old_time;
     s.time = new_time;
-  } else {
+  } else
+  {
     otm_update_time_step(s);
     s.dt = s.max_stable_dt * in.CFL;
     s.time += s.dt;
+  }
+}
+
+void
+otm_update_neighbor_distances(input const& in, state& s)
+{
+  if (in.enable_adapt)
+  {
+    if (in.use_constant_dt) update_nearest_point_neighbor_distances(s);
+    update_nearest_node_neighbor_distances(s);
+    update_min_nearest_neighbor_distances(s);
   }
 }
 
@@ -675,6 +716,7 @@ void otm_time_integrator_step(input const& in, state& s)
   }
   otm_update_shape_functions(s);
   otm_update_time(in, s);
+  otm_update_neighbor_distances(in, s);
 }
 
 void otm_run(input const& in, state& s)

--- a/v3/otm_search.cpp
+++ b/v3/otm_search.cpp
@@ -170,7 +170,7 @@ void do_otm_iterative_point_support_search(lgr::state &s, int min_support_nodes_
     do_search_and_fill_counts(search_nodes, queries, s.points, offsets, indices, counts);
 
     min_nodes_in_support_over_all_points = reduce_min(hpc::device_policy(), counts,
-        std::numeric_limits<int>::max());
+        hpc::numeric_limits<int>::max());
   }
 
   size_and_fill_lgr_data_structures(s.points, indices, counts, s.points_to_point_nodes,

--- a/v3/otm_search_util.hpp
+++ b/v3/otm_search_util.hpp
@@ -5,7 +5,6 @@
 #include <hpc_vector.hpp>
 #include <lgr_mesh_indices.hpp>
 
-
 namespace lgr {
 namespace search_util {
 

--- a/v3/unit_tests/CMakeLists.txt
+++ b/v3/unit_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ option(LGR_ENABLE_UNIT_TESTS "Build support for unit tests" ON)
 
 if (LGR_ENABLE_UNIT_TESTS)
   set(LGR_UNIT_SOURCES
+    adapt.cpp
     distances.cpp
     materials.cpp
     maxent.cpp

--- a/v3/unit_tests/adapt.cpp
+++ b/v3/unit_tests/adapt.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+#include <gtest/internal/gtest-internal.h>
+#include <hpc_macros.hpp>
+#include <hpc_range_sum.hpp>
+#include <hpc_vector.hpp>
+#include <lgr_mesh_indices.hpp>
+#include <lgr_state.hpp>
+#include <otm_adapt.hpp>
+#include <otm_distance.hpp>
+#include <otm_search.hpp>
+#include <otm_search_util.hpp>
+#include <unit_tests/otm_unit_mesh.hpp>
+#include <unit_tests/unit_arborx_testing_util.hpp>
+#include <unit_tests/unit_device_util.hpp>
+#include <cassert>
+
+using namespace lgr;
+using namespace lgr::search_util;
+
+class adapt: public ::testing::Test
+{
+  void SetUp() override
+  {
+    lgr_unit::arborx_testing_singleton::instance();
+  }
+};
+
+namespace {
+
+template<typename Index>
+HPC_NOINLINE inline void fill_adapt_op_and_other_entities(const nearest_neighbors<Index> &n,
+    const hpc::counting_range<Index> &range,
+    const hpc::length<double> nearest_criterion,
+    const hpc::device_vector<hpc::length<double>, Index>& criteria,
+    hpc::device_vector<Index, Index> &other_entities,
+    hpc::device_vector<adapt_op, Index>& adapt_ops)
+{
+  auto others = other_entities.begin();
+  auto ops = adapt_ops.begin();
+  auto neighbor_ords = n.entities_to_neighbor_ordinals.cbegin();
+  auto neighbors = n.entities_to_neighbors.cbegin();
+  auto crit = criteria.cbegin();
+  auto func = [=] HPC_DEVICE (const Index i)
+  {
+    if (crit[i] > nearest_criterion)
+    {
+      auto neighbor_range = neighbor_ords[i];
+      assert(neighbor_range.size() == 1);
+      others[i] = neighbors[neighbor_range[0]];
+      ops[i] = adapt_op::SPLIT;
+    } else
+    {
+      others[i] = Index(-1);
+      ops[i] = adapt_op::NONE;
+    }
+  };
+  hpc::for_each(hpc::device_policy(), range, func);
+}
+
+HPC_NOINLINE inline void evaluate_node_adapt(const state& s, otm_adapt_state& a,
+    const hpc::length<double> min_dist)
+{
+  node_neighbors n;
+  search::do_otm_node_nearest_node_search(s, n, 1);
+  compute_node_neighbor_squared_distances(s, n, a.node_criteria);
+  fill_adapt_op_and_other_entities(n, s.nodes, min_dist, a.node_criteria, a.other_node, a.node_op);
+}
+
+HPC_NOINLINE inline void evaluate_point_adapt(const state& s, otm_adapt_state& a,
+    const hpc::length<double> min_dist)
+{
+  point_neighbors n;
+  search::do_otm_point_nearest_point_search(s, n, 1);
+  compute_point_neighbor_squared_distances(s, n, a.point_criteria);
+  fill_adapt_op_and_other_entities(n, s.points, min_dist, a.point_criteria, a.other_point, a.point_op);
+}
+
+}
+
+TEST_F(adapt, can_create_otm_adapt_state_from_lgr_state)
+{
+  state s;
+  tetrahedron_single_point(s);
+  ASSERT_NO_THROW(otm_adapt_state a(s));
+}
+
+HPC_NOINLINE inline void expect_all_nodes_are_adaptivity_candidates(const otm_adapt_state& a,
+    const state& s) {
+  auto ops = a.node_op.cbegin();
+  auto other = a.other_node.cbegin();
+  auto check_func = DEVICE_TEST (const node_index i) {
+    DEVICE_EXPECT_EQ(ops[i], adapt_op::SPLIT);
+    DEVICE_EXPECT_NE(other[i], -1);
+  };
+  unit::test_for_each(hpc::device_policy(), s.nodes, check_func);
+}
+
+HPC_NOINLINE inline void expect_all_points_are_adaptivity_candidates(const otm_adapt_state& a,
+    const state& s) {
+  auto ops = a.point_op.cbegin();
+  auto other = a.other_point.cbegin();
+  auto check_func = DEVICE_TEST (const point_index i) {
+    DEVICE_EXPECT_EQ(ops[i], adapt_op::SPLIT);
+    DEVICE_EXPECT_NE(other[i], -1);
+  };
+  unit::test_for_each(hpc::device_policy(), s.points, check_func);
+}
+
+TEST_F(adapt, can_compute_node_nearest_node_neighbor_distances_as_adapt_criteria)
+{
+  state s;
+  tetrahedron_single_point(s);
+
+  otm_adapt_state a(s);
+
+  constexpr hpc::length<double> min_dist(0.1);
+  evaluate_node_adapt(s, a, min_dist);
+
+  EXPECT_EQ(a.node_criteria.size(), a.node_counts.size());
+  EXPECT_EQ(a.other_node.size(), a.node_counts.size());
+
+  expect_all_nodes_are_adaptivity_candidates(a, s);
+}
+
+TEST_F(adapt, can_compute_point_nearest_point_neighbor_distances_as_adapt_criteria)
+{
+  state s;
+  two_tetrahedra_two_points(s);
+
+  otm_adapt_state a(s);
+
+  constexpr hpc::length<double> min_dist(0.1);
+  evaluate_point_adapt(s, a, min_dist);
+
+  EXPECT_EQ(a.point_criteria.size(), a.point_counts.size());
+  EXPECT_EQ(a.other_point.size(), a.point_counts.size());
+
+  expect_all_points_are_adaptivity_candidates(a, s);
+}

--- a/v3/unit_tests/unit_device_util.hpp
+++ b/v3/unit_tests/unit_device_util.hpp
@@ -9,12 +9,16 @@
 #define DEVICE_TEST(a) [=] HPC_DEVICE(a, int& num_fails)
 #define DEVICE_ASSERT_EQ(a, b) if (a != b) { ++num_fails; return; }
 #define DEVICE_EXPECT_EQ(a, b) if (a != b) { ++num_fails; }
+#define DEVICE_ASSERT_NE(a, b) if (a == b) { ++num_fails; return; }
+#define DEVICE_EXPECT_NE(a, b) if (a == b) { ++num_fails; }
 #define DEVICE_EXPECT_TRUE(a) if (!a) { ++num_fails; }
 #define DEVICE_EXPECT_FALSE(a) if (a) { ++num_fails; }
 #else
 #define DEVICE_TEST(a) [=] HPC_DEVICE(a)
 #define DEVICE_ASSERT_EQ(a, b) ASSERT_EQ(a, b)
 #define DEVICE_EXPECT_EQ(a, b) EXPECT_EQ(a, b)
+#define DEVICE_ASSERT_NE(a, b) ASSERT_NE(a, b)
+#define DEVICE_EXPECT_NE(a, b) EXPECT_NE(a, b)
 #define DEVICE_EXPECT_TRUE(a) EXPECT_TRUE(a)
 #define DEVICE_EXPECT_FALSE(a) EXPECT_FALSE(a)
 #endif
@@ -51,7 +55,7 @@ private:
 }
 
 template<typename PolicyType, class Range, class FuncType>
-HPC_NOINLINE void test_for_each(PolicyType policy, Range const range, const FuncType func)
+HPC_NOINLINE void test_for_each(PolicyType policy, Range const& range, const FuncType func)
 {
   int init(0);
   auto num_test_failures = hpc::transform_reduce(policy, range, init, hpc::plus<int>(),

--- a/v3/unit_tests/unit_device_util.hpp
+++ b/v3/unit_tests/unit_device_util.hpp
@@ -11,6 +11,10 @@
 #define DEVICE_EXPECT_EQ(a, b) if (a != b) { ++num_fails; }
 #define DEVICE_ASSERT_NE(a, b) if (a == b) { ++num_fails; return; }
 #define DEVICE_EXPECT_NE(a, b) if (a == b) { ++num_fails; }
+#define DEVICE_ASSERT_GT(a, b) if (a <= b) { ++num_fails; return; }
+#define DEVICE_EXPECT_GT(a, b) if (a <= b) { ++num_fails; }
+#define DEVICE_ASSERT_LT(a, b) if (a >= b) { ++num_fails; return; }
+#define DEVICE_EXPECT_LT(a, b) if (a >= b) { ++num_fails; }
 #define DEVICE_EXPECT_TRUE(a) if (!a) { ++num_fails; }
 #define DEVICE_EXPECT_FALSE(a) if (a) { ++num_fails; }
 #else
@@ -19,6 +23,10 @@
 #define DEVICE_EXPECT_EQ(a, b) EXPECT_EQ(a, b)
 #define DEVICE_ASSERT_NE(a, b) ASSERT_NE(a, b)
 #define DEVICE_EXPECT_NE(a, b) EXPECT_NE(a, b)
+#define DEVICE_ASSERT_GT(a, b) ASSERT_GT(a, b)
+#define DEVICE_EXPECT_GT(a, b) EXPECT_GT(a, b)
+#define DEVICE_ASSERT_LT(a, b) ASSERT_LT(a, b)
+#define DEVICE_EXPECT_LT(a, b) EXPECT_LT(a, b)
 #define DEVICE_EXPECT_TRUE(a) EXPECT_TRUE(a)
 #define DEVICE_EXPECT_FALSE(a) EXPECT_FALSE(a)
 #endif


### PR DESCRIPTION
@lxmota @btalami prototyping some adaptivity for nodes and points that follows from the lgr_adapt code. Please take a look (don't merge, I don't think it's ready for primetime yet, as I am still adding testing) and let me know if the interface makes sense (at least for node-to-node interpolation). We can also walk through it together if you'd like. Does not currently support collapse operations (i.e., deleting a point or node). But this would be easy enough to support.

The strategy is currently based on the "naive" algorithm we discussed, in which we determine if a node's (or point's) nearest neighbor is too far away, then we add one in between.