### PR TITLE
Use OTM state data structures to avoid doing extra search in adaptivity.

### DIFF
--- a/v3/CMakeLists.txt
+++ b/v3/CMakeLists.txt
@@ -14,7 +14,7 @@ if (LGR_ENABLE_CUDA)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --compiler-options -Wall,-Wextra,-Werror,-Wno-noexcept-type --Werror cross-execution-space-call,deprecated-declarations --expt-extended-lambda")
   if (CMAKE_CXX_COMPILER MATCHES ".*nvcc_wrapper")
     message(STATUS "Detected nvcc_wrapper as C++/CUDA compiler")
-    set(LGR_EXTRA_NVCC_WRAPPER_FLAGS "-Wall -Wextra -Werror -Wno-noexcept-type -Wno-cross-execution-space-call -Wno-deprecated-declarations")
+    set(LGR_EXTRA_NVCC_WRAPPER_FLAGS "-Wall -Wextra -Werror -Wno-noexcept-type -Wno-deprecated-declarations")
     set(LGR_USE_NVCC_WRAPPER ON)
     if (NOT LGR_ENABLE_SEARCH)
       find_package(Kokkos REQUIRED)
@@ -58,6 +58,7 @@ set(OTM_SOURCES
     otm_adapt.cpp
     otm_apps.cpp
     otm_distance.cpp
+    otm_distance_util.cpp
     otm_meshing.cpp
     otm_meshless.cpp
     otm_search.cpp

--- a/v3/hpc_macros.hpp
+++ b/v3/hpc_macros.hpp
@@ -57,8 +57,8 @@
 #ifdef __CUDACC__
 #define HPC_ERROR_EXIT_IMPL(msg)                                       \
   do {                                                                 \
-    printf("%s ********** HPC_ERROR at ");                             \
-    printf("%s +%d", __FILE__, __LINE__);                              \
+    printf("********** HPC_ERROR at ");                                \
+    printf("%s:%d\n  %s", __FILE__, __LINE__, msg);                    \
     assert(0);                                                         \
   } while (0)
 #else

--- a/v3/lgr_physics.cpp
+++ b/v3/lgr_physics.cpp
@@ -910,7 +910,8 @@ void run(input const& in, std::string const& filename) {
   } else {
     auto const err_code = lgr::read_exodus_file(filename, in, s);
     if (err_code != 0) {
-      HPC_ERROR_EXIT("Reading Exodus file : " << filename);
+      std::string const error_msg = "Error reading Exodus file : " + filename;
+      HPC_ERROR_EXIT(error_msg.c_str());
     }
   }
   if (in.x_transform) in.x_transform(&s.x);

--- a/v3/lgr_state.hpp
+++ b/v3/lgr_state.hpp
@@ -88,7 +88,9 @@ class state {
   hpc::device_array_vector<hpc::position<double>, point_index> xp; // current point positions
   hpc::device_array_vector<hpc::acceleration<double>, point_index> b; // acceleration corresponding to body force, mostly for weight
   hpc::device_vector<hpc::length<double>, point_index> h_otm; // characteristic length, used for max-ent functions
+  hpc::device_vector<point_index, point_index> nearest_point_neighbor; // nearest point neighbor
   hpc::device_vector<hpc::length<double>, point_index> nearest_point_neighbor_dist; // distance to nearest point neighbor
+  hpc::device_vector<node_index, node_index> nearest_node_neighbor; // nearest point neighbor
   hpc::device_vector<hpc::length<double>, point_index> nearest_node_neighbor_dist; // distance to nearest point neighbor
   hpc::device_vector<hpc::energy_density<double>, point_node_index> potential_density; // Helmholtz energy density
   hpc::host_array_vector<hpc::velocity<double>, material_index> prescribed_v;

--- a/v3/otm_apps.cpp
+++ b/v3/otm_apps.cpp
@@ -95,7 +95,7 @@ bool otm_j2_nu_zero_patch_test()
   in.xp_transform = std::ref(point_interpolator);
   auto const err_code = read_exodus_file(filename, in, s);
   if (err_code != 0) {
-    HPC_ERROR_EXIT("Reading Exodus file : " << filename);
+    HPC_ERROR_EXIT("Error reading Exodus file : cube.g");
   }
   in.name = "nu-zero-patch-test";
   in.end_time = 1.0e-03;
@@ -198,7 +198,7 @@ bool otm_j2_uniaxial_patch_test()
   in.xp_transform = std::ref(point_interpolator);
   auto const err_code = read_exodus_file(filename, in, s);
   if (err_code != 0) {
-    HPC_ERROR_EXIT("Reading Exodus file : " << filename);
+    HPC_ERROR_EXIT("Error reading Exodus file : cube.g");
   }
   in.name = "uniaxial-patch-test";
   in.end_time = 1.0e-03;
@@ -312,7 +312,7 @@ bool otm_cylindrical_flyer()
   in.xp_transform = std::ref(point_interpolator);
   auto const err_code = read_exodus_file(filename, in, s);
   if (err_code != 0) {
-    HPC_ERROR_EXIT("Reading Exodus file : " << filename);
+    HPC_ERROR_EXIT("Error reading Exodus file : cylinder.g");
   }
   in.name = "cylindrical-flyer";
   in.end_time = 1.0e-04;

--- a/v3/otm_distance_util.cpp
+++ b/v3/otm_distance_util.cpp
@@ -1,0 +1,91 @@
+#include <hpc_algorithm.hpp>
+#include <hpc_dimensional.hpp>
+#include <hpc_execution.hpp>
+#include <hpc_functional.hpp>
+#include <hpc_macros.hpp>
+#include <hpc_range.hpp>
+#include <hpc_transform_reduce.hpp>
+#include <hpc_vector.hpp>
+#include <lgr_state.hpp>
+#include <otm_distance.hpp>
+#include <otm_distance_util.hpp>
+#include <otm_search.hpp>
+#include <otm_search_util.hpp>
+#include <cassert>
+#include <limits>
+
+namespace lgr {
+
+template <typename Index>
+HPC_NOINLINE inline void compute_sqrt_nearest_neighbor_distances(const hpc::counting_range<Index>& range,
+    hpc::device_vector<hpc::length<double>, Index>& dists)
+{
+  assert( dists.size() == range.size() );
+  auto const neighbor_distances = dists.begin();
+  auto dist_func = [=] HPC_DEVICE (Index const i) {
+    auto const dist = std::sqrt(neighbor_distances[i]);
+    neighbor_distances[i] = dist;
+  };
+  hpc::for_each(hpc::device_policy(), range, dist_func);
+}
+
+template<typename Index>
+HPC_NOINLINE inline void fill_nearest_neighbors(const hpc::counting_range<Index> &range,
+    const search_util::nearest_neighbors<Index> &neighbors,
+    hpc::device_vector<Index, Index> &nearest_neighbor)
+{
+  assert(nearest_neighbor.size() == range.size());
+  assert(neighbors.entities_to_neighbors.size() == range.size());
+  auto const result = nearest_neighbor.begin();
+  auto const nearest_ordinal = neighbors.entities_to_neighbor_ordinals.cbegin();
+  auto const nearest = neighbors.entities_to_neighbors.cbegin();
+  auto dist_func = [=] HPC_DEVICE (Index const i)
+  {
+    auto const nearest_ord = nearest_ordinal[i];
+    assert(nearest_ord.size() == 1);
+    result[i] = nearest[nearest_ord[0]];
+  };
+  hpc::for_each(hpc::device_policy(), range, dist_func);
+}
+
+void otm_update_nearest_point_neighbor_distances(state &s)
+{
+  hpc::fill(hpc::device_policy(), s.nearest_point_neighbor_dist, -1.0);
+  hpc::fill(hpc::device_policy(), s.nearest_point_neighbor, point_index(-1));
+  search_util::point_neighbors n;
+  search::do_otm_point_nearest_point_search(s, n, 1);
+
+  if (n.entities_to_neighbors.empty()) return;
+
+  search_util::compute_point_neighbor_squared_distances(s, n, s.nearest_point_neighbor_dist);
+  compute_sqrt_nearest_neighbor_distances(s.points, s.nearest_point_neighbor_dist);
+  fill_nearest_neighbors(s.points, n, s.nearest_point_neighbor);
+}
+
+void otm_update_nearest_node_neighbor_distances(state &s)
+{
+  hpc::fill(hpc::device_policy(), s.nearest_node_neighbor_dist, -1.0);
+  hpc::fill(hpc::device_policy(), s.nearest_node_neighbor, node_index(-1));
+  search_util::node_neighbors n;
+  search::do_otm_node_nearest_node_search(s, n, 1);
+
+  if (n.entities_to_neighbors.empty()) return;
+
+  search_util::compute_node_neighbor_squared_distances(s, n, s.nearest_node_neighbor_dist);
+  compute_sqrt_nearest_neighbor_distances(s.nodes, s.nearest_node_neighbor_dist);
+  fill_nearest_neighbors(s.nodes, n, s.nearest_node_neighbor);
+}
+
+void otm_update_min_nearest_neighbor_distances(state &s)
+{
+  // TODO compute a relative change in distance as a metric...average?
+  hpc::length<double> const init = std::numeric_limits<double>::max();
+  s.min_node_neighbor_dist = hpc::transform_reduce(hpc::device_policy(),
+      s.nearest_node_neighbor_dist, init, hpc::minimum<hpc::length<double>>(),
+      hpc::identity<hpc::length<double>>());
+  s.min_point_neighbor_dist = hpc::transform_reduce(hpc::device_policy(),
+      s.nearest_point_neighbor_dist, init, hpc::minimum<hpc::length<double>>(),
+      hpc::identity<hpc::length<double>>());
+}
+
+}

--- a/v3/otm_distance_util.hpp
+++ b/v3/otm_distance_util.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace lgr {
+class state;
+}
+
+namespace lgr {
+
+void otm_update_nearest_point_neighbor_distances(state &s);
+void otm_update_nearest_node_neighbor_distances(state &s);
+void otm_update_min_nearest_neighbor_distances(state &s);
+
+}

--- a/v3/otm_materials.hpp
+++ b/v3/otm_materials.hpp
@@ -112,7 +112,7 @@ HPC_ALWAYS_INLINE HPC_HOST_DEVICE void variational_J2_point(hpc::deformation_gra
       ++iters;
     }
     if (!converged) {
-      HPC_ERROR_EXIT("variational J2 diverged" << std::endl);
+      HPC_ERROR_EXIT("variational J2 diverged\n");
       // TODO: handle non-convergence error
     }
     //std::cout << "variational J2 converged in " << iters << " iterations" << std::endl;

--- a/v3/otm_tetrahedron_util.hpp
+++ b/v3/otm_tetrahedron_util.hpp
@@ -29,7 +29,7 @@ tet_parametric_to_physical(hpc::array<hpc::position<double>, 4> const& xn,
   switch (points_per_element)
   {
   default:
-    HPC_ERROR_EXIT("Invalid number of integration points : " << points_per_element << '\n');
+    HPC_ERROR_EXIT("Invalid number of integration points");
     break;
   case 1:
     xp = 0.25 * (xn[0] + xn[1] + xn[2] + xn[3]);
@@ -38,7 +38,7 @@ tet_parametric_to_physical(hpc::array<hpc::position<double>, 4> const& xn,
     switch (ip)
     {
     default:
-      HPC_ERROR_EXIT("Invalid integration point index : " << ip << '\n');
+      HPC_ERROR_EXIT("Invalid integration point index");
       break;
     case 0:
       xp = wa * xn[0] + wb * (xn[1] + xn[2] + xn[3]);

--- a/v3/unit_tests/adapt.cpp
+++ b/v3/unit_tests/adapt.cpp
@@ -15,6 +15,7 @@
 #include <lgr_state.hpp>
 #include <otm_adapt.hpp>
 #include <otm_adapt_util.hpp>
+#include <otm_distance_util.hpp>
 #include <otm_meshless.hpp>
 #include <otm_search.hpp>
 #include <otm_vtk.hpp>
@@ -32,6 +33,20 @@ class adapt: public ::testing::Test
     lgr_unit::arborx_testing_singleton::instance();
   }
 };
+
+namespace {
+
+inline void set_up_node_and_point_data_for_adapt(state& s) {
+  s.nearest_node_neighbor.resize(s.nodes.size());
+  s.nearest_node_neighbor_dist.resize(s.nodes.size());
+  s.nearest_point_neighbor.resize(s.points.size());
+  s.nearest_point_neighbor_dist.resize(s.points.size());
+
+  otm_update_nearest_node_neighbor_distances(s);
+  otm_update_nearest_point_neighbor_distances(s);
+}
+
+}
 
 TEST_F(adapt, can_create_otm_adapt_state_from_lgr_state)
 {
@@ -67,6 +82,8 @@ TEST_F(adapt, can_compute_node_nearest_node_neighbor_distances_as_criteria)
   state s;
   tetrahedron_single_point(s);
 
+  set_up_node_and_point_data_for_adapt(s);
+
   otm_adapt_state a(s);
 
   constexpr hpc::length<double> min_dist(0.1);
@@ -82,6 +99,8 @@ TEST_F(adapt, can_compute_point_nearest_point_neighbor_distances_as_criteria)
 {
   state s;
   two_tetrahedra_two_points(s);
+
+  set_up_node_and_point_data_for_adapt(s);
 
   otm_adapt_state a(s);
 
@@ -135,6 +154,8 @@ TEST_F(adapt, can_choose_correct_node_adaptivity_based_on_nearest_neighbor)
   state s;
   tetrahedron_single_point(s);
 
+  set_up_node_and_point_data_for_adapt(s);
+
   otm_adapt_state a(s);
 
   constexpr hpc::length<double> min_dist(0.1);
@@ -148,6 +169,8 @@ TEST_F(adapt, can_choose_correct_point_adaptivity_based_on_nearest_neighbor)
 {
   state s;
   two_tetrahedra_two_points(s);
+
+  set_up_node_and_point_data_for_adapt(s);
 
   otm_adapt_state a(s);
 
@@ -199,6 +222,8 @@ TEST_F(adapt, can_apply_node_adaptivity)
 {
   state s;
   tetrahedron_single_point(s);
+
+  set_up_node_and_point_data_for_adapt(s);
 
   otm_adapt_state a(s);
 
@@ -274,6 +299,8 @@ TEST_F(adapt, can_apply_point_adaptivity)
   state s;
   two_tetrahedra_two_points(s);
 
+  set_up_node_and_point_data_for_adapt(s);
+
   otm_adapt_state a(s);
 
   constexpr hpc::length<double> max_allowable_neighbor_dist(0.1);
@@ -305,6 +332,8 @@ TEST_F(adapt, performance_test_adapt)
 {
   state s;
   elastic_wave_four_points_per_tetrahedron(s);
+
+  set_up_node_and_point_data_for_adapt(s);
 
   input in(0, 0);
 


### PR DESCRIPTION
  Move some routines into separate header/source files.

  Fix broken HPC_ERROR_EXIT on GPU build.